### PR TITLE
update EdgeGen schedule and Feishu sync

### DIFF
--- a/docs/feishu-sync.md
+++ b/docs/feishu-sync.md
@@ -10,12 +10,15 @@ npm run sync:feishu
 
 默认模式不会把飞书表格当成完整历史库，所以不会清空仓库里原有的历史组会记录。
 
-脚本会先读取飞书表格里的有效记录，再按「组会汇报时间」排序：
+脚本会先读取仓库现有的 `schedules.js` 和飞书表格里的有效记录，再按「组会汇报时间」判断记录位置：
 
-- 时间最新的一条写入 `upcoming_schedules`
-- 其他飞书记录合并进历史 `schedules`
+- 只有「组会汇报时间」还没到、并且尚未存在于历史 `schedules` 中的记录，才会进入 `upcoming_schedules`
+- 如果有多条未来记录，时间最近的一条写入 `upcoming_schedules`
+- 已经过期的飞书记录会合并进历史 `schedules`
 - 仓库里已有的历史 `schedules` 会继续保留
-- 如果同一条记录已经存在，会用飞书里的版本更新它，避免重复
+- 如果同一条历史记录已经存在，默认保留仓库里的版本，避免飞书记录重复写入历史
+
+如果 `ppt` / `Slides` 列是飞书附件，脚本会把附件下载到仓库的 `slides/` 目录，并在 `schedules.js` 里写成 `/slides/文件名` 这样的站内链接，建议附件使用 PDF。下载附件需要飞书应用开通媒体下载相关权限，例如 `docs:document.media:download` 或 `drive:drive:readonly`。如果权限不足，脚本会失败退出，避免把需要鉴权的 `open-apis/drive/.../download` 链接写进公开网页。
 
 如果某一天飞书表格已经包含完整历史数据，可以改用完整覆盖模式：
 
@@ -85,16 +88,15 @@ git push origin <your-branch>
 
 - `论文标题`：论文完整标题，对应网站里的 `title`
 - `会议/期刊`：例如 `NSDI'26`、`SOSP'25`，对应 `conf`
-- `汇报人`：组会上讲这篇论文的人，对应 `presenter`
+- `汇报人`：组会上讲这篇论文的人，对应 `presenter`，建议填写英文名
 - `组会汇报时间`：建议用飞书「日期」字段，包含日期和具体时间；脚本会用这一列判断哪条是 upcoming
 
 建议填写列：
 
-- `主持人`：对应 `facilitator`，没有就留空
 - `地点`：例如 `Room ARTS1021 @ SEU & Online`，不填会用默认地点
 - `腾讯会议`：腾讯会议链接，会显示成 `TencentMeeting`
 - `论文链接`：论文 PDF、arXiv、DOI、DBLP 或官网链接，会显示在详情里
-- `ppt`：组会 slides 链接；如果已经上传到仓库，可以填 `/slides/xxx.pdf`
+- `ppt`：组会 slides 链接或飞书附件；如果填飞书附件，脚本会下载到 `slides/` 并改写为 `/slides/文件名`
 - `录屏`：视频或回放链接，会显示成 `Videos`
 
 可选管理列：
@@ -104,4 +106,7 @@ git push origin <your-branch>
 
 可以保留但脚本暂时不使用的列：
 
+- `主持人`：网站里的 `facilitator` 由仓库的 `schedules.js` 手动维护，脚本不会从飞书读取
 - `作者`：现在网站页面没有展示作者字段，所以脚本会忽略这一列
+
+如果飞书里已经有中文姓名，可以在 `scripts/sync-feishu.js` 的 `nameAliases` 里添加映射，让输出到网站的 `presenter` 保持英文。

--- a/schedules.js
+++ b/schedules.js
@@ -1,2624 +1,2647 @@
 var upcoming_schedules = [
+    {
+        "title": "EdgeGen: Efficient LLM-Empowered Model Generation with Quantization-Aware NAS",
+        "conf": "WWW'26",
+        "presenter": "Chenhui Shi",
+        "facilitator": "Ziang Qin, Mengxuan Liu",
+        "date": "June 8, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qmvxYw51Cnez"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-06-08-WWW'26-EdgeGen.pdf"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3774904.3792394"
+        }
+    }
 ]
 
 var schedules = [
-{
-    "title": "A House United Within Itself: SLO-Awareness for On-Premises Containerized ML Inference Clusters via Faro",
-    "conf": "Eurosys'25",
-    "presenter": "Mengxuan Liu",
-    "facilitator": "Chenhui Shi, Jianyu Jiang",
-    "date": "June 1, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/qmvxYw51Cnez"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-06-01-Eurosys'25-Faro.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-06-01-Eurosys'25-Faro",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2409.19488"
-    }
-},
-{
-    "title": "Marconi: Prefix Caching for the Era of Hybrid LLMs",
-    "conf": "MLSys'25",
-    "presenter": "Jianyu Jiang",
-    "facilitator": "Mengxuan Liu, Xuehuai Hong",
-    "date": "May 25, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-05-25-MLSys'25-Marconi.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-05-25-MLSys'25-Marconi",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2411.19379"
-    }
-},
-{
-    "title": "Weaver: Efficient Multi-LLM Serving with Attention Offloading",
-    "conf": "ATC'25",
-    "presenter": "Xuehuai Hong",
-    "facilitator": "Jianyu Jiang, Minxin Sun",
-    "date": "May 18, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-05-18-ATC'25-Weaver.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-05-18-ATC'25-Weaver",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/system/files/atc25-gao.pdf"
-    }
-},
-{
-    "title": "Activation-Informed Merging of Large Language Models",
-    "conf": "NeurIPS'25",
-    "presenter": "MinXin Sun",
-    "facilitator": "Xuehuai Hong, Wanqi Liu",
-    "date": "May 11, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-05-11-NeurIPS'25-AIM.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-05-11-NeurIPS'25-AIM",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2502.02421"
-    }
-},
-{
-    "title": "AutoLife: Automatic Life Journaling with Smartphones and LLMs",
-    "conf": "UbiComp'25",
-    "presenter": "Wanqi Liu",
-    "facilitator": "Minxin Sun, Xin Wang",
-    "date": "April 27, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-04-27-UbiComp'25-AutoLife.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-04-27-UbiComp'25-AutoLife",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dapowan.github.io/files/AutoLife.pdf"
-    }
-},
-{
-    "title": "Fuyun: Bridging the Semantic Gap in Serverless Resource Provisioning via LLM Agents",
-    "conf": "AgenticOS'26",
-    "presenter": "Xin Wang",
-    "facilitator": "Wanqi Liu, Kaiqi Gu",
-    "date": "April 20, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-04-20-AgenticOS'26-Funyun.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-04-20-AgenticOS'26-Funyun",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://os-for-agent.github.io/papers/AgenticOS_2026_paper_16.pdf"
-    }
-},
-{
-    "title": "HydraServe:Minimizing Cold Start Latency for Serverless LLM Serving in Public Clouds",
-    "conf": "NSDI'26",
-    "presenter": "Kaiqi Gu",
-    "facilitator": "Xin Wang, Shizhe Xue",
-    "date": "April 13, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-04-13-NSDI'26-HydraServe.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-04-13-NSDI'26-HydraServe",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2502.15524"
-    }
-},
-{
-    "title": "FineBadminton: A Multi-Level Dataset for Fine-Grained  Badminton Video Understanding",
-    "conf": "ACM MM'25",
-    "presenter": "Shizhe Xue",
-    "facilitator": "Kaiqi Gu, Ling Xu",
-    "date": "April 7, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-04-07-ACMMM'25-FineBadminton.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-04-07-ACMMM'25-FineBadminton",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2508.07554"
-    }
-},
-{
-    "title": "FAST: Efficient Robot Action Tokenization",
-    "conf": "RSS'25",
-    "presenter": "Ling Xu",
-    "facilitator": "Shizhe Xue, Lili Pan",
-    "date": "April 7, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-04-07-RSS'25.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-04-07-RSS'25",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.pi.website/research/fast"
-    }
-},
-{
-    "title": "In Prospect and Retrospect: Reflective Memory Management for Long-term Personalized Dialogue Agents",
-    "conf": "ACL'25",
-    "presenter": "Lili Pan",
-    "facilitator": "Ling Xu, Hangshuai He",
-    "date": "March 30, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-03-30-ACL'25-Reflective_Memory.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-03-30-ACL'25-Reflective_Memory",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://aclanthology.org/2025.acl-long.413.pdf"
-    }
-},
-{
-    "title": "Never Start from Scratch: Expediting On-Device LLM Personalization via Explainable Model Selection",
-    "conf": "Mobisys'25",
-    "presenter": "Hangshuai He",
-    "facilitator": "Lili Pan, Haoran Ma",
-    "date": "March 23, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-03-23-Mobisys'25-Never_Start_from_Scratch.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-03-23-Mobisys'25-Never_Start_from_Scratch",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2504.13938"
-    }
-},
-{
-    "title": "Pie: A Programmable Serving System for Emerging LLM Applications",
-    "conf": "SOSP'25",
-    "presenter": "Haoran Ma",
-    "facilitator": "Hangshuai He, Yujie Chen",
-    "date": "January 19, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-01-19-SOSP'25-Pie.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-01-19-SOSP'25-Pie",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2510.24051"
-    }
-},
-{
-    "title": "Harnessing Inter-GPU Shared Memory for Seamless MoE Communication-Computation Fusion",
-    "conf": "PPoPP'25",
-    "presenter": "Yujie Chen",
-    "facilitator": "Botai Sun, Haoran Ma",
-    "date": "January 12, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-01-13-PPoPP'25-CCFuser.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-01-13-PPoPP'25-CCFuser",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3710848.3710868"
-    }
-},
-{
-    "title": "SyCCL: Exploiting Symmetry for Efficient Collective Communication Scheduling",
-    "conf": "SIGCOMM'25",
-    "presenter": "Botai Sun",
-    "facilitator": "Yujie Cheng, Haoran Ma",
-    "date": "January 5, 2026.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2026-01-05-SIGCOMM'25-SyCCL.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2026-01-05-SIGCOMM'25-SyCCL",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/pdf/10.1145/3718958.3750499"
-    }
-},
-{
-    "title": "HeurAgenix: Leveraging LLMs for Solving Complex Combinatorial Optimization Challenges",
-    "conf": "arxiv'25",
-    "presenter": "Changshuo Yao",
-    "facilitator": "Botai Sun, Yujie Chen",
-    "date": "December 29, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-12-29-arxiv'25-HeurAgenix.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-12-29-arxiv'25-HeurAgenix"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2506.15196"
-    }
-},
-{
-    "title": "Enhancing QoE in Collaborative Edge Systems With Feedback Diffusion Generative Scheduling",
-    "conf": "TMC'25",
-    "presenter": "Yuxiang Lu",
-    "facilitator": "Kai Huang, Chengqing Zhao",
-    "date": "Decmber 15, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-12-15-TMC'25-FDEdge.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-12-15-TMC'25-FDEdge",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://ieeexplore.ieee.org/document/11077726"
-    }
-},
-{
-    "title": "Fork: A Dual Congestion Control Loop for Small and  Large Flows in Datacenters",
-    "conf": "EuroSys'25",
-    "presenter": "Kai Huang",
-    "facilitator": "Muhan Yuan, Yuxiang Lu",
-    "date": "December 8, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-12-08-EuroSys'25-Fork.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-12-08-EuroSys'25-Fork",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3689031.3696101"
-    }
-},
-{
-    "title": "Multi-Turn Code Generation Through Single-Step Rewards",
-    "conf": "ICML'25",
-    "presenter": "Muhan Yuan",
-    "facilitator": "Kai Huang, Yuxiang Lu",
-    "date": "December 1, 2025. ",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-12-01-ICML'25-Multi-Turn.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-12-01-ICML'25-Multi-Turn"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://openreview.net/pdf?id=aJeLhLcsh0"
-    }
-},
-{
-    "title": "Pruner: A Draft-then-Verify Exploration Mechanism to Accelerate Tensor Program Tuning",
-    "conf": "ASPLOS'25",
-    "presenter": "Weilong Wang",
-    "facilitator": "Tianen Liu, Chengqing Zhao",
-    "date": "November 24, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-11-24-ASPLOS'25-Pruner.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-11-24-ASPLOS'25-Pruner"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/abs/10.1145/3676641.3716269"
-    }
-},
-{
-    "title": "AVA: Towards Agentic Video Analytics with Vision Language Models",
-    "conf": "NSDI'26",
-    "presenter": "Tianen Liu",
-    "facilitator": "Tianen Liu",
-    "date": "November 17, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-11-17-NSDI'26-AVA.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-11-17-NSDI'26-AVA",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2505.00254"
-    }
-},
-{
-    "title": "ReLoop: A Self-Correction Continual Learning Loop for Recommender Systems",
-    "conf": "SIGIR'22",
-    "presenter": "Lingfei Xu",
-    "facilitator": "Lingfei Xu",
-    "date": "November 10, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-11-10-SIGIR'22-ReLoop.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-11-10-SIGIR'22-ReLoop",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2204.11165"
-    }
-},
-{
-    "title": "AutoDroid-V2: Boosting SLM-based GUI Agents via Code Generation",
-    "conf": "MobiSys'25",
-    "presenter": "Chuanhua Fan",
-    "facilitator": "Chuanhua Fan",
-    "date": "November 3, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-11-03-MobiSys'25-AutoDroid-V2.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-11-03-MobiSys'25-AutoDroid-V2",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2412.18116"
-    }
-},
-{
-    "title": "WLB-LLM: Workload-Balanced 4D Parallelism for Large Language Model Training",
-    "conf": "OSDI'25",
-    "presenter": "Yi Liu",
-    "facilitator": "Yi Liu",
-    "date": "October 27, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-10-27-OSDI'25-WLB_LLM.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-10-27-OSDI'25-WLB_LLM",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2503.17924"
-    }
-},
-{
-    "title": "Ubiquitous memory augmentation via mobile multimodal embedding system",
-    "conf": "Nature'25",
-    "presenter": "Yuankun Feng",
-    "facilitator": "Yuankun Feng",
-    "date": "October 20, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-10-20-NatureComm'25-Reminisce.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-10-20-NatureComm'25-Reminisce",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.nature.com/articles/s41467-025-60802-5"
-    }
-},
-{
-    "title": "Unlocking ECMP Programmability for Precise Traffic Control",
-    "conf": "NSDI'25",
-    "presenter": "Junan Lu",
-    "facilitator": "Yujie Chen",
-    "date": "October 13, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-10-13-NSDI'25-ECMP_Program.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-10-13-NSDI'25-ECMP_Program",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/conference/nsdi25/presentation/liu-yadong"
-    }
-},
-{
-    "title": "White-Boxing RDMA with Packet-Granular Software Control",
-    "conf": "NSDI'25",
-    "presenter": "Kai Huang",
-    "facilitator": "Yujie Chen",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-NSDI'25-SCR.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NSDI'25-SCR",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.5555/3767955.3767978"
-    }
-},
-{
-    "title": "AutoCCL: Automated Collective Communication Tuning for Accelerating Distributed and Parallel DNN Training",
-    "conf": "NSDI'25",
-    "presenter": "Yujie Chen",
-    "facilitator": "Yujie Chen",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-NSDI'25-AutoCCL.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NSDI'25-AutoCCL",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/conference/nsdi25/presentation/xu-guanbin"
-    }
-},
-{
-    "title": "rStar-Math: Small LLMs Can Master Math Reasoning with Self-Evolved Deep Thinking",
-    "conf": "ICML'25",
-    "presenter": "Zhaonian Wang",
-    "facilitator": "Yitao Wang",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-ICML'25-rStar-Math.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-ICML'25-rStar-Math",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2501.04519"
-    }
-},
-{
-    "title": "Diffusion Language Model",
-    "conf": "None",
-    "presenter": "Zikang Chen",
-    "facilitator": "Yitao Wang",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-Diffuison-Language-Model.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-Diffuison-Language-Model",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": ""
-    }
-},
-{
-    "title": "Memory OS of AI Agent",
-    "conf": "EMNLP'25",
-    "presenter": "Haoran Ma",
-    "facilitator": "Yitao Wang",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-EMNLP'25-MemoryOS.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-EMNLP'25-MemoryOS",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2506.06326"
-    }
-},
-{
-    "title": "Supporting Our AI Overlords: Redesigning Data Systems to be Agent-First",
-    "conf": "SAA'25",
-    "presenter": "Fanglei Shu",
-    "facilitator": "Yitao Wang",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-SAA'25-DataSystems.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-SAA'25-DataSystems",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2509.00997"
-    }
-},
-{
-    "title": "Memp: Exploring Agent Procedural Memory",
-    "conf": "arXiv'25",
-    "presenter": "Yitao Wang",
-    "facilitator": "Yitao Wang",
-    "date": "September 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-arXiv'25-Memp.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-arXiv'25-Memp",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2508.06433"
-    }
-},
-{
-    "title": "AlphaEvolve: A coding agent for scientific and algorithmic discovery",
-    "conf": "Google DeepMind",
-    "presenter": "Lili Pan",
-    "facilitator": "Jiawei Liu",
-    "date": "September 20, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-Google'25-AlphaEvolve.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-Google'25-AlphaEvolve",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2506.13131"
-    }
-},
-{
-    "title": "RAP: Retrieval-Augmented Planning with Contextual Memory for Multimodal LLM Agents",
-    "conf": "NeurIPS'24",
-    "presenter": "Xingcai Zhang",
-    "facilitator": "Jiawei Liu",
-    "date": "September 20, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-NeurIPS'24-RAP.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NeurIPS'24-RAP",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2402.03610"
-    }
-},
-{
-    "title": "CMT: A Memory Compression Method for Continual Knowledge Learning of Large Language Models",
-    "conf": "AAAI'25",
-    "presenter": "Jiawei Liu",
-    "facilitator": "Jiawei Liu",
-    "date": "September 20, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-20-AAAI'25-CMT.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-20-AAAI'25-CMT",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2412.07393"
-    }
-},
-{
-    "title": "Optimizing Large Language Model Training Using FP4 Quantization",
-    "conf": "ICML'25",
-    "presenter": "Yifan Hu",
-    "facilitator": "Botai Sun",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-ICML'25-FP4.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ICML'25-FP4",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2501.17116"
-    }
-},
-{
-    "title": "D2MoE: Dual Routing and Dynamic Scheduling for Efficient On-Device MoE-based LLM Serving",
-    "conf": "MobiCom'25",
-    "presenter": "Yunpeng Xu",
-    "facilitator": "Botai Sun",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-Mobicom'25-D2MoE.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-Mobicom'25-D2MoE",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2504.15299"
-    }
-},
-{
-    "title": "Nazar: Monitoring and Adapting ML Models on Mobile Devices",
-    "conf": "ASPLOS'25",
-    "presenter": "Botai Sun",
-    "facilitator": "Botai Sun",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-ASPLOS'25-Nazar.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ASPLOS'25-Nazar",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3669940.3707246"
-    }
-},
-{
-    "title": "AutoML-Agent: A Multi-Agent LLM Framework for Full-Pipeline AutoML",
-    "conf": "ICML'25",
-    "presenter": "Jinhan Xin",
-    "facilitator": "Weilong Wang",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-ICML'25-AutoML-Agent.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ICML'25-AutoML-Agent",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2410.02958"
-    }
-},
-{
-    "title": "Bayesian Code Diffusion for Efficient Automatic Deep Learning Program Optimization",
-    "conf": "OSDI'25",
-    "presenter": "Hangshuai He",
-    "facilitator": "Weilong Wang",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-OSDI'25-Bayesian.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-OSDI'25-Bayesian",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.5555/3767901.3767918"
-    }
-},
-{
-    "title": "AutoMMLab: Automatically Generating Deployable Models from Language Instructions for Computer Vision Tasks",
-    "conf": "AAAI'25",
-    "presenter": "Weilong Wang",
-    "facilitator": "Weilong Wang",
-    "date": "September 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-AAAI'25-AutoMMLab.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-AAAI'25-AutoMMLab",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2402.15351"
-    }
-},
-{
-    "title": "Adda: Towards Efficient in-Database Feature Generation via LLM-based Agents",
-    "conf": "SIGMOD'25",
-    "presenter": "Qingyang Song",
-    "facilitator": "Tianen Liu",
-    "date": "September 18, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-SIGMOD'25-Adda.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGMOD'25-Adda",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3725262"
-    }
-},
-{
-    "title": "E2ETune: End-to-End Knob Tuning via Fine-tuned Generative Language Model",
-    "conf": "VLDB'25",
-    "presenter": "Yuxiang Lu",
-    "facilitator": "Tianen Liu",
-    "date": "September 18, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-VLDB'25-E2ETune.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-VLDB'25-E2ETune",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2404.11581"
-    }
-},
-{
-    "title": "Intent-Driven Network Management with Multi-Agent LLMs: The Confucius Framework",
-    "conf": "SIGCOMM'25",
-    "presenter": "Minyuan Feng",
-    "facilitator": "Tianen Liu",
-    "date": "September 18, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-SIGCOMM'25-Confucius.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGCOMM'25-Confucius",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3718958.3750537"
-    }
-},
-{
-    "title": "𝜆-Tune: Harnessing Large Language Models for Automated Database System Tuning",
-    "conf": "SIGMOD'25",
-    "presenter": "Bin Dong",
-    "facilitator": "Tianen Liu",
-    "date": "September 18, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-SIGMOD'25-lambda-Tune.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGMOD'25-lambda-Tune",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3709652"
-    }
-},
-{
-    "title": "ConfigBot: Adaptive Resource Allocation for Robot Applications in Dynamic Environments",
-    "conf": "IROS'25",
-    "presenter": "Tianen Liu",
-    "facilitator": "Tianen Liu",
-    "date": "September 18, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-18-IROS'25-ConfigBot.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-18-IROS'25-ConfigBot",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2501.10513"
-    }
-},
-{
-    "title": "HybriMoE: Hybrid CPU-GPU Scheduling and Cache Management for Efficient MoE Inference",
-    "conf": "DAC'25",
-    "presenter": "Changshuo Yao",
-    "facilitator": "Muhan Yuan, Hangshuai He",
-    "date": "September 11, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/GWm1Xp6OtLOM"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-12-DAC'25-HybriMoE.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-12-DAC'25-HybriMoE",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2504.05897"
-    }
-},
-{
-    "title": "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models",
-    "conf": "ICML'25",
-    "presenter": "Muhan Yuan",
-    "facilitator": "Muhan Yuan",
-    "date": "September 4, 2025.",
-    "time": "9:30 a.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/GWm1Xp6OtLOM"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-09-04-ICML'25-Revisiting_Chain_of_Thou.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-09-04-ICML'25-Revisiting_Chain_of_Thou",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/abs/2201.11903"
-    }
-},
-{
-    "title": "CogSys: Efficient and Scalable Neurosymbolic Cognition System via Algorithm-Hardware Co-Design",
-    "conf": "HPCA'25",
-    "presenter": "Qingyang Song",
-    "facilitator": "Qingyang Song",
-    "date": "July 25, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-07-25-HPCA'25-CogSys.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-07-25-HPCA'25-CogSys",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2503.01162"
-    }
-},
-{
-    "title": "A Workload-Aware DVFS Robust to Concurrent Tasks for Mobile Devices",
-    "conf": "MOBICOM'23",
-    "presenter": "Minyuan Feng",
-    "facilitator": "Haoran Ma, Hangshuai He",
-    "date": "July 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-07-18-MOBICOM'23-Gear.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-07-18-MOBICOM'23-Gear",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/pdf/10.1145/3570361.3592524"
-    }
-},
-{
-    "title": "ARIA: Optimizing Vision Foundation Model Inference on Heterogeneous Mobile Processors for Augmented Reality",
-    "conf": "MobiSys'25",
-    "presenter": "Haoran Ma",
-    "facilitator": "Lili Pan, Minyuan Feng",
-    "date": "July 11, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-07-11-MobiSys'25-ARIA.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-07-11-MobiSys'25-ARIA",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://mobed.yonsei.ac.kr/mobed_pages/pdf/aria-mobisys25.pdf"
-    }
-},
-{
-    "title": "GPIoT: Tailoring Small Language Models for IoT Program Synthesis and Development",
-    "conf": "SENSYS'25",
-    "presenter": "Lili Pan",
-    "facilitator": "Kai Huang, Haoran Ma",
-    "date": "JULY 4, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-07-04-Sensys'25-GPIoT.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-07-04-Sensys'25-GPIoT",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/pdf/10.1145/3715014.3722064"
-    }
-},
-{
-    "title": "Optimizing generative AI by backpropagating language model feedback",
-    "conf": "Nature'25",
-    "presenter": "Xingcai Zhang",
-    "facilitator": "Yujie Chen, Bing Dong",
-    "date": "JUNE 20, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-06-20-Nature'25-TextGrad.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-06-20-Nature'25-TextGrad",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.nature.com/articles/s41586-025-08661-4"
-    }
-},
-{
-    "title": "TaskSense: A Translation-like Approach for Tasking HeterogeneousSensor Systems with LLMs",
-    "conf": "SenSys'25",
-    "presenter": "Bing Dong",
-    "facilitator": "Yitao Wang, Xingcai Zhang",
-    "date": "June 13, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-06-13-SenSys'25-TaskSense.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-06-13-SenSys'25-TaskSense",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/pdf/10.1145/3715014.3722070"
-    }
-},
-{
-    "title": "Punica: Multi-Tenant LoRA Serving",
-    "conf": "MLSys'24",
-    "presenter": "Kai Huang",
-    "facilitator": "Changshuo Yao, Lili Pan",
-    "date": "June 6, 2025",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-06-06-MLSys'24-Punica.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-06-06-MLSys'24-Punica",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "http://arxiv.org/pdf/2310.18547v1"
-    }
-},
-{
-    "title": "SimAI: Unifying Architecture Design and Performance Tuning for Large-Scale  Large Language Model Training with Scalability and Precision",
-    "conf": "NSDI'25",
-    "presenter": "Botai Sun",
-    "facilitator": "Yujie Chen, Changshuo Yao",
-    "date": "May 30, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-30-NDSI'25-SimAI.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-30-NDSI'25-SimAI",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/system/files/nsdi25-wang-xizheng-simai.pdf"
-    }
-},
-{
-    "title": "CA-LoRA: Adapting Existing LoRA for Compressed LLMs to Enable Efficient Multi-Tasking on Personal Devices",
-    "conf": "COLM'24",
-    "presenter": "Junan Lu",
-    "facilitator": "Yi Liu, Junan Lu",
-    "date": "May 23, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-23-COLM'24-CA-LoRA.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-23-COLM'24-CA-LoRA"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "http://arxiv.org/pdf/2307.07705v3"
-    }
-},
-{
-    "title": "SpotServe: Serving Generative Large Language Models on Preemptible Instances",
-    "conf": "ASPLOS'24",
-    "presenter": "Yi Liu",
-    "facilitator": "Yi Liu, Junan Lu",
-    "date": "May 23, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-23-ASPLOS'24-SpotServe.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-23-ASPLOS'24-SpotServe"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2311.15566"
-    }
-},
-{
-    "title": "LoongServe: Efficiently Serving Long-Context Large Language Models with Elastic Sequence Parallelism",
-    "conf": "SOSP'24",
-    "presenter": "Yifan Hu",
-    "facilitator": "Yunpeng Xu, Yifan Hu",
-    "date": "May 16, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-16-SOSP'24-LoongServe.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-16-SOSP'24-LoongServe"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2404.09526v2"
-    }
-},
-{
-    "title": "Proteus: A High-Throughput Inference-Serving System with Accuracy Scaling",
-    "conf": "ASPLOS'24",
-    "presenter": "Yunpeng Xu",
-    "facilitator": "Yunpeng Xu, Yifan Hu",
-    "date": "May 16, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-16-ASPLOS'24-Proteus.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-16-ASPLOS'24-Proteus"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://groups.cs.umass.edu/ramesh/wp-content/uploads/sites/3/2023/09/ljWiUS-asplos24spring-final29.pdf"
-    }
-},
-{
-    "title": "Characterization of Large Language Model Development in theDatacenter",
-    "conf": "NSDI'24",
-    "presenter": "Zhaonian Wang",
-    "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
-    "date": "May 9, 2025",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-09-NSDI'24-Characterization_of_LLM.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-09-NSDI'24-Characterization_of_LLM"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/system/files/nsdi24-hu.pdf"
-    }
-},
-{
-    "title": "From Exploration to Mastery: Enabling LLMs to Master Tools via Self-Driven Interactions",
-    "conf": "ICLR'25",
-    "presenter": "Jinhan Xin",
-    "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
-    "date": "May 9, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-09-ICLR'25-From_Exploration_to_Mastery.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-09-ICLR'25-From_Exploration_to_Mastery"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2410.08197"
-    }
-},
-{
-    "title": "Autothrottle: A Practical Bi-Level Approach to Resource Management for SLO-Targeted Microservices",
-    "conf": "NSDI'24",
-    "presenter": "Chuanhua Fan",
-    "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
-    "date": "May 9, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-05-09-NSDI'24-Autothrottle.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-05-09-NSDI'24-Autothrottle"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/system/files/nsdi24-wang-zibo.pdf"
-    }
-},
-{
-    "title": "INFERCEPT:Efficient Intercept Support for Augmented Large Language Model Inference",
-    "conf": "ICML'24",
-    "presenter": "Zikang Chen",
-    "facilitator": "Yuankun Feng, Zikang Chen",
-    "date": "April 25,2025",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-04-25-ICML'24-INFERCEPT.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-04-25-ICML'24-INFERCEPT"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://arxiv.org/pdf/2402.01869"
-    }
-},
-{
-    "title": "LLM-Pruner: On the Structural Pruning of Large Language Models",
-    "conf": "NeurIPS'23",
-    "presenter": "Yuankun Feng",
-    "facilitator": "Yuankun Feng, Zikang Chen",
-    "date": "April 25,2025",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-04-25-NeurIPS'23-LLM-Pruner.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-04-25-NeurIPS'23-LLM-Pruner"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://proceedings.neurips.cc/paper_files/paper/2023/file/44956951349095f74492a5471128a7e0-Paper-Conference.pdf"
-    }
-},
-{
-    "title": "Parcae: Proactive, Liveput-Optimized DNN Training on Preemptible Instances",
-    "conf": "NSDI'24",
-    "presenter": "Yujie Chen",
-    "facilitator": "Botai Sun, Xingcai Zhang",
-    "date": "April 18, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-04-18-NSDI'24-Parcae.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-04-18-NSDI'24-Parcae",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://www.usenix.org/system/files/nsdi24-duan.pdf"
-    }
-},
-{
-    "title": "8-bit Transformer Inference and Fine-tuning for Edge Accelerators",
-    "conf": "ASPLOS'24",
-    "presenter": "Changshuo Yao",
-    "facilitator": "Botai Sun, Kai Huang",
-    "date": "April 11, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-04-11-ASPLOS'24-8bit_Transformer.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-04-11-ASPLOS'24-8bit_Transformer",
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "https://dl.acm.org/doi/10.1145/3620666.3651368"
-    }
-},
-{
-    "title": "GPTuner: A Manual-Reading Database Tuning System via  GPT-Guided Bayesian Optimization",
-    "conf": "VLDB'24",
-    "presenter": "Yuxiang Lu",
-    "facilitator": "Hangshuai He, Songtao Lu",
-    "date": "March 21, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-03-21-VLDB'24-GPTuner.pdf"
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-03-21-VLDB'24-GPTuner"
-        }
-    ],
-    "dblp": {
-        "source": "website",
-        "url": "GPTuner: A Manual-Reading Database Tuning System via GPT-Guided Bayesian Optimization"
-    }
-},
-{
-    "title": "Enabling Tensor Language Model to Assist in Generating High-Performance Tensor Programs for Deep Learning",
-    "conf": "OSDI'24",
-    "presenter": "Hangshuai He",
-    "facilitator": "Minyuan Feng, Yuxiang Lu",
-    "date": "March 14, 2025.",
-    "time": "2:00 p.m.",
-    "location": "Room ARTS1021 @ SEU & Online",
-    "links": [
-        {
-            "title": "TencentMeeting",
-            "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
-        },
-        {
-            "title": "Slides",
-            "url": "/slides/2025-03-14-OSDI'24-Enabling.pdf",
-        },
-        {
-            "title": "Videos",
-            "url": "http://10.201.0.220:8099/?meeting=2025-03-14-OSDI'24-Enabling",
-        }
-    ],
-    "dblp": {
-        "source": "DBLP",
-        "url": "https://www.usenix.org/system/files/osdi24-zhai.pdf"
-    }
-},    
-{
-    "title":"DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving",
-    "conf":"OSDI'24",
-    "presenter":"Yitao Wang",
-    "facilitator":"Fanglei Shu, Bing Dong",
-    "date":"March 7, 2025.",
-    "time":"2:00 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/qvug5ylXPFkh"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2025-03-07-NDSI'24-distserve.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2025-03-07-NDSI'24-distserve"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/system/files/osdi24-zhong-yinmin.pdf"
-    }
-},
-{
-    "title":"ISOLATEGPT: An Execution Isolation  Architecture for LLM-Based Agentic Systems",
-    "conf":"NDSS'25",
-    "presenter":"Fanglei Shu",
-    "facilitator":"Yachen Wu, Yitao Wang",
-    "date":"February 28, 2025.",
-    "time":"2:30 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/3higw0fO3laq"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2025-02-28-NDSS'25-Isolategpt.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2025-02-28-NDSS'25-Isolategpt"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/pdf/2403.04960"
-    }
-},
-{
-    "title":"BumbleBee: Dynamic KV-Cache Streaming Submodular Summarization for Infinite-Context Transformers",
-    "conf":"COLM'24",
-    "presenter":"Yachen Wu",
-    "facilitator":"Jiawei Liu, Fanglei Shu",
-    "date":"January 16, 2025.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/3higw0fO3laq"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2025-01-16-COLM'24-BumbleBee.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2025-01-16-COLM'24-BumbleBee"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://openreview.net/pdf?id=8w0RApM5yG"
-    }
-},
- {
-    "title":"Modality Plug-and-Play: Runtime Modality Adaptation in LLM-Driven Autonomous Mobile Systems",
-    "conf":"MobiCom'25",
-    "presenter":"Jiawei Liu",
-    "facilitator":"Tianen Liu, Yachen Wu",
-    "date":"January 10, 2025.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/nzkCPK31Bcqx"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2025-01-10-MobiCom'25-Modality-Plug-and-Play.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2025-01-10-MobiCom'25-Modality-Plug-and-Play"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/pdf/2312.07886"
-    }
-},
-{
-    "title":"Perceptual-Centric Image Super-Resolution using Heterogeneous Processors on Mobile Devices",
-    "conf":"MobiCom'24",
-    "presenter":"Tianen Liu",
-    "facilitator":"Chengqing Zhao, Jiawei Liu",
-    "date":"December 27, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":""
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-12-27-MobiCom'24-Super-Resolution.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-12-27-MobiCom'24-Super-Resolution"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://dl.acm.org/doi/10.1145/3636534.3690698"
-    }
-},
-{
-    "title":"Alps: An Adaptive Learning, Priority OS Scheduler for Serverless Function",
-    "conf":"ATC'24",
-    "presenter":"Chengqing Zhao",
-    "facilitator":"Weilong Wang, Tianen Liu",
-    "date":"December 20, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/nUErptQGpSPL"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-12-20-ATC'24-Alps.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-12-20-ATC'24-Alps"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/system/files/atc24-fu.pdf"
-    }
-},
-{
-    "title":"Can’t Be Late: Optimizing Spot Instance Savings under Deadlines",
-    "conf":"NSDI'24",
-    "presenter":"Weilong Wang",
-    "facilitator":"Tiange Xia, Chengqing Zhao",
-    "date":"December 20, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/nUErptQGpSPL"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-12-20-NSDI'24-SPOTWORK.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-12-20-NSDI'24-SPOTWORK"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/system/files/nsdi24-wu-zhanghao.pdf"
-    }
-},
- {
-    "title":"EDGE-LLM: Enabling Efficient Large Language Model Adaptation on Edge Devices via Layerwise Unified Compression and Adaptive Layer Tuning & Voting",
-    "conf":"DAC'24",
-    "presenter":"Tiange Xia",
-    "facilitator":"Weilong Wang, Muhan Yuan",
-    "date":"November 29, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/T6vST3H5tfBV"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-29-DAC'24-EDGELLM.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-29-DAC'24-EDGELLM"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://dl.acm.org/doi/pdf/10.1145/3649329.3658473"
-    }
-},
-{
-    "title":"WebVoyager: Building an End-to-End Web Agent with Large Multimodal Models",
-    "conf":"ACL'24",
-    "presenter":"Muhan Yuan",
-    "facilitator":"Lili Pan, Kai Huang",
-    "date":"November 22, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/COZdhdwGNJuc"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-22-ACL'24-WebVoyager.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-22-ACL'24-WebVoyager"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2401.13919"
-    }
-},
-{
-    "title":"Fast On-device LLM Inference with NPUs",
-    "conf":"ASPLOS'25",
-    "presenter":"Changshuo Yao",
-    "facilitator":"Chuanyou Li",
-    "date":"November 15, 2024.",
-    "time":"10:10 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/yehYWE3IKQaM"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-15-ASPLOS'25-FODLLM.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-15-ASPLOS'25-FODLLM"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2407.05858"
-    }
-},
-{
-    "title":"NetLLM: Adapting Large Language Models for Networking",
-    "conf":"SIGCOMM'24",
-    "presenter":"Bin Dong",
-    "facilitator":"Borui Li",
-    "date":"November 15, 2024.",
-    "time":"9:30 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/yehYWE3IKQaM"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-15-SIGCOMM'24-NetLLM.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-15-SIGCOMM'24-NetLLM"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2402.02338"
-    }
-},
-{
-    "title":"Keep the Cost Down:A Review on Methods to Optimize LLM's KV Cache Consumption",
-    "conf":"CoLM'24",
-    "presenter":"Yachen Wu",
-    "facilitator":"Chuanyou Li",
-    "date":"November 10, 2024.",
-    "time":"5:30 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-CoLM'24-KVCache.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-CoLM'24-KVCache"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2407.18003"
-    }
-},
-{
-    "title":"ExeGPT: Constraint-Aware Resource Scheduling for LLM Inference",
-    "conf":"ASPLOS'24",
-    "presenter":"Songtao Lu",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"4:55 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-ASPLOS'24-ExeGPT.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-ASPLOS'24-ExeGPT"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2404.07947"
-    }
-},
-{
-    "title":"AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversations",
-    "conf":"COLM'24",
-    "presenter":"Fanglei Shu",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"4:20 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-COLM'24-AutoGen.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-COLM'24-AutoGen"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2308.08155"
-    }
-},
-{
-    "title":"HuggingGPT: Solving AI Tasks with ChatGPT and its Friends in Hugging Face",
-    "conf":"NeurIPS'23",
-    "presenter":"Xingcai Zhang",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"4:00 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-ACL'24-AgentPro.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-ACL'24-AgentPro"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/pdf/2303.17580"
-    }
-},
-{
-    "title":"Agent-Pro: Learning to Evolve via Policy-Level Reflection and Optimization",
-    "conf":"ACL'24",
-    "presenter":"Xingcai Zhang",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"3:45 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-ACL'24-AgentPro.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-ACL'24-AgentPro"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2402.17574"
-    }
-},
-{
-    "title":"A Language Agent for Autonomous Driving",
-    "conf":"COLM'24",
-    "presenter":"Hangshuai He",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"3:10 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-COLM'24-LAFAD.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-COLM'24-LAFAD"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/abs/2311.10813"
-    }
-},
-{
-    "title":"ChatIoT: Zero-code Generation of Trigger-action Based IoT Programs",
-    "conf":"Ubicomp'24",
-    "presenter":"Lili Pan",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"2:35 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-Ubicomp'24-ChatIoT.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-Ubicomp'24-ChatIoT"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://dl.acm.org/doi/abs/10.1145/3678585"
-    }
-},
-{
-    "title":"Hairpin: Rethinking Packet Loss Recovery in Edge-based Interactive Video Streaming",
-    "conf":"NSDI'24",
-    "presenter":"Botai Sun",
-    "facilitator":"Chuanyou Li",
-    "date":"November 10, 2024.",
-    "time":"2:00 p.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-NSDI'24-Hairpin.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-NSDI'24-Hairpin"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/meng"
-    }
-},
-{
-    "title":"SLNet: A Spectrogram Learning Neural Network for Deep Wireless Sensing",
-    "conf":"NSDI'23",
-    "presenter":"Yujie Chen",
-    "facilitator":"Chuanyou Li",
-    "date":"November 10, 2024.",
-    "time":"10:55 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-NSDI'23-SLNet.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-NSDI'23-SLNet"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi23/presentation/yang-zheng"
-    }
-},
-{
-    "title":"INVAR: Inversion Aware Resource Provisioning and Workload Scheduling for Edge Computing",
-    "conf":"INFOCOM'24",
-    "presenter":"Kai Huang",
-    "facilitator":"Chuanyou Li",
-    "date":"November 10, 2024.",
-    "time":"10:20 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-INFOCOM'24-INVAR.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-INFOCOM'24-INVAR"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://ieeexplore.ieee.org/document/10621417"
-    }
-},
-{
-    "title":"Apparate: Rethinking Early Exits to Tame Latency-Throughput Tensions in ML Serving",
-    "conf":"SOSP'24",
-    "presenter":"Minyuan Feng",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"9:45 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-SOSP'24-Apparate.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-SOSP'24-Apparate"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://arxiv.org/pdf/2312.05385"
-    }
-},
-{
-    "title":"FlexNN: Efficient and Adaptive DNN Inference on Memory-Constrained Edge Devices",
-    "conf":"MobiCom'24",
-    "presenter":"Yuxiang Lu",
-    "facilitator":"Borui Li",
-    "date":"November 10, 2024.",
-    "time":"9:10 a.m.",
-    "location":"Room ARTS1021 @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-11-10-MobiCom'24-FlexNN.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-11-10-MobiCom'24-FlexNN"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://dl.acm.org/doi/pdf/10.1145/3636534.3649391"
-    }
-},
-{
-    "title":"LitePred: Transferable and Scalable Latency Prediction for Hardware-Aware Neural Architecture Search",
-    "conf":"NSDI'24",
-    "presenter":"Changshuo Yao",
-    "facilitator":"Chuanyou Li",
-    "date":"July 25, 2024.",
-    "time":"7:00 p.m.",
-    "location":"Room CS @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/8CGH1csJOVp4"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-07-25-NSDI'24-LitePred.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-07-25-NSDI'24-LitePred"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/feng-chengquan"
-    }
-},
-{
-    "title":"CASSINI: Network-Aware Job Scheduling in Machine Learning Clusters",
-    "conf":"NSDI'24",
-    "presenter":"Botai Sun",
-    "facilitator":"Chuanyou Li",
-    "date":"July 18, 2024.",
-    "time":"7:00 p.m.",
-    "location":"Room CS @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/RfNf0JCHCja7"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-07-18-NSDI'24-CASSINI.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-07-18-NSDI'24-CASSINI"
-        }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/rajasekaran"
-    }
-},
-{
-    "title":"MadEye: Boosting Live Video Analytics Accuracy with Adaptive Camera Configurations",
-    "conf":"NSDI'24",
-    "presenter":"Yujie Chen",
-    "facilitator":"Chuanyou Li",
-    "date":"July 11, 2024.",
-    "time":"8:00 p.m.",
-    "location":"Room CS @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/1ytQw5VuAPv0"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-07-11-NSDI'24-MadEye.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-07-11-NSDI'24-MadEye"
-        }
+    {
+        "title": "A House United Within Itself: SLO-Awareness for On-Premises Containerized ML Inference Clusters via Faro",
+        "conf": "Eurosys'25",
+        "presenter": "Mengxuan Liu",
+        "facilitator": "Chenhui Shi, Jianyu Jiang",
+        "date": "June 1, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qmvxYw51Cnez"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-06-01-Eurosys'25-Faro.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-06-01-Eurosys'25-Faro"
+            }
         ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/wong"
-    }
-},
-{
-    "title":"Vulcan: Automatic Query Planning for Live ML Analytics",
-    "conf":"NSDI'24",
-    "presenter":"Minyuan Feng",
-    "facilitator":"Borui Li",
-    "date":"July 11, 2024.",
-    "time":"7:00 p.m.",
-    "location":"Room CS @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/1ytQw5VuAPv0"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-07-11-NSDI'24-Vulcan.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-07-11-NSDI'24-Vulcan"
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2409.19488"
         }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/zhang-yiwen"
-    }
-},
-{
-    "title":"Accelerating Neural Recommendation Training with Embedding Scheduling",
-    "conf":"NSDI'24",
-    "presenter":"Kai Huang",
-    "facilitator":"Chuanyou Li",
-    "date":"July 4, 2024.",
-    "time":"7:00 p.m.",
-    "location":"Room CS @ SEU & Online",
-    "links":[
-        {
-            "title":"TencentMeeting",
-            "url":"https://meeting.tencent.com/dm/cGqoEdimqm2W"
-        },
-        {
-            "title":"Slides",
-            "url":"/slides/2024-07-04-NSDI'24-ANRT.pdf"
-        },
-        {
-            "title":"Videos",
-            "url":"http://10.201.0.220:8099/?meeting=2024-07-04-NSDI'24-ANRT"
+    },
+    {
+        "title": "Marconi: Prefix Caching for the Era of Hybrid LLMs",
+        "conf": "MLSys'25",
+        "presenter": "Jianyu Jiang",
+        "facilitator": "Mengxuan Liu, Xuehuai Hong",
+        "date": "May 25, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-05-25-MLSys'25-Marconi.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-05-25-MLSys'25-Marconi"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2411.19379"
         }
-    ],
-    "dblp":{
-        "source":"DBLP",
-        "url":"https://www.usenix.org/conference/nsdi24/presentation/zeng"
+    },
+    {
+        "title": "Weaver: Efficient Multi-LLM Serving with Attention Offloading",
+        "conf": "ATC'25",
+        "presenter": "Xuehuai Hong",
+        "facilitator": "Jianyu Jiang, Minxin Sun",
+        "date": "May 18, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-05-18-ATC'25-Weaver.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-05-18-ATC'25-Weaver"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/system/files/atc25-gao.pdf"
+        }
+    },
+    {
+        "title": "Activation-Informed Merging of Large Language Models",
+        "conf": "NeurIPS'25",
+        "presenter": "MinXin Sun",
+        "facilitator": "Xuehuai Hong, Wanqi Liu",
+        "date": "May 11, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-05-11-NeurIPS'25-AIM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-05-11-NeurIPS'25-AIM"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2502.02421"
+        }
+    },
+    {
+        "title": "AutoLife: Automatic Life Journaling with Smartphones and LLMs",
+        "conf": "UbiComp'25",
+        "presenter": "Wanqi Liu",
+        "facilitator": "Minxin Sun, Xin Wang",
+        "date": "April 27, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-04-27-UbiComp'25-AutoLife.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-04-27-UbiComp'25-AutoLife"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dapowan.github.io/files/AutoLife.pdf"
+        }
+    },
+    {
+        "title": "Fuyun: Bridging the Semantic Gap in Serverless Resource Provisioning via LLM Agents",
+        "conf": "AgenticOS'26",
+        "presenter": "Xin Wang",
+        "facilitator": "Wanqi Liu, Kaiqi Gu",
+        "date": "April 20, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-04-20-AgenticOS'26-Funyun.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-04-20-AgenticOS'26-Funyun"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://os-for-agent.github.io/papers/AgenticOS_2026_paper_16.pdf"
+        }
+    },
+    {
+        "title": "HydraServe:Minimizing Cold Start Latency for Serverless LLM Serving in Public Clouds",
+        "conf": "NSDI'26",
+        "presenter": "Kaiqi Gu",
+        "facilitator": "Xin Wang, Shizhe Xue",
+        "date": "April 13, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-04-13-NSDI'26-HydraServe.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-04-13-NSDI'26-HydraServe"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2502.15524"
+        }
+    },
+    {
+        "title": "FineBadminton: A Multi-Level Dataset for Fine-Grained  Badminton Video Understanding",
+        "conf": "ACM MM'25",
+        "presenter": "Shizhe Xue",
+        "facilitator": "Kaiqi Gu, Ling Xu",
+        "date": "April 7, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-04-07-ACMMM'25-FineBadminton.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-04-07-ACMMM'25-FineBadminton"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2508.07554"
+        }
+    },
+    {
+        "title": "FAST: Efficient Robot Action Tokenization",
+        "conf": "RSS'25",
+        "presenter": "Ling Xu",
+        "facilitator": "Shizhe Xue, Lili Pan",
+        "date": "April 7, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-04-07-RSS'25.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-04-07-RSS'25"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.pi.website/research/fast"
+        }
+    },
+    {
+        "title": "In Prospect and Retrospect: Reflective Memory Management for Long-term Personalized Dialogue Agents",
+        "conf": "ACL'25",
+        "presenter": "Lili Pan",
+        "facilitator": "Ling Xu, Hangshuai He",
+        "date": "March 30, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-03-30-ACL'25-Reflective_Memory.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-03-30-ACL'25-Reflective_Memory"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://aclanthology.org/2025.acl-long.413.pdf"
+        }
+    },
+    {
+        "title": "Never Start from Scratch: Expediting On-Device LLM Personalization via Explainable Model Selection",
+        "conf": "Mobisys'25",
+        "presenter": "Hangshuai He",
+        "facilitator": "Lili Pan, Haoran Ma",
+        "date": "March 23, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/n4NIP7NvTHRb"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-03-23-Mobisys'25-Never_Start_from_Scratch.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-03-23-Mobisys'25-Never_Start_from_Scratch"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2504.13938"
+        }
+    },
+    {
+        "title": "Pie: A Programmable Serving System for Emerging LLM Applications",
+        "conf": "SOSP'25",
+        "presenter": "Haoran Ma",
+        "facilitator": "Hangshuai He, Yujie Chen",
+        "date": "January 19, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-01-19-SOSP'25-Pie.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-01-19-SOSP'25-Pie"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2510.24051"
+        }
+    },
+    {
+        "title": "Harnessing Inter-GPU Shared Memory for Seamless MoE Communication-Computation Fusion",
+        "conf": "PPoPP'25",
+        "presenter": "Yujie Chen",
+        "facilitator": "Botai Sun, Haoran Ma",
+        "date": "January 12, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-01-13-PPoPP'25-CCFuser.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-01-13-PPoPP'25-CCFuser"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3710848.3710868"
+        }
+    },
+    {
+        "title": "SyCCL: Exploiting Symmetry for Efficient Collective Communication Scheduling",
+        "conf": "SIGCOMM'25",
+        "presenter": "Botai Sun",
+        "facilitator": "Yujie Cheng, Haoran Ma",
+        "date": "January 5, 2026.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2026-01-05-SIGCOMM'25-SyCCL.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2026-01-05-SIGCOMM'25-SyCCL"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3718958.3750499"
+        }
+    },
+    {
+        "title": "HeurAgenix: Leveraging LLMs for Solving Complex Combinatorial Optimization Challenges",
+        "conf": "arxiv'25",
+        "presenter": "Changshuo Yao",
+        "facilitator": "Botai Sun, Yujie Chen",
+        "date": "December 29, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-12-29-arxiv'25-HeurAgenix.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-12-29-arxiv'25-HeurAgenix"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2506.15196"
+        }
+    },
+    {
+        "title": "Enhancing QoE in Collaborative Edge Systems With Feedback Diffusion Generative Scheduling",
+        "conf": "TMC'25",
+        "presenter": "Yuxiang Lu",
+        "facilitator": "Kai Huang, Chengqing Zhao",
+        "date": "Decmber 15, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-12-15-TMC'25-FDEdge.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-12-15-TMC'25-FDEdge"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://ieeexplore.ieee.org/document/11077726"
+        }
+    },
+    {
+        "title": "Fork: A Dual Congestion Control Loop for Small and  Large Flows in Datacenters",
+        "conf": "EuroSys'25",
+        "presenter": "Kai Huang",
+        "facilitator": "Muhan Yuan, Yuxiang Lu",
+        "date": "December 8, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-12-08-EuroSys'25-Fork.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-12-08-EuroSys'25-Fork"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3689031.3696101"
+        }
+    },
+    {
+        "title": "Multi-Turn Code Generation Through Single-Step Rewards",
+        "conf": "ICML'25",
+        "presenter": "Muhan Yuan",
+        "facilitator": "Kai Huang, Yuxiang Lu",
+        "date": "December 1, 2025. ",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-12-01-ICML'25-Multi-Turn.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-12-01-ICML'25-Multi-Turn"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://openreview.net/pdf?id=aJeLhLcsh0"
+        }
+    },
+    {
+        "title": "Pruner: A Draft-then-Verify Exploration Mechanism to Accelerate Tensor Program Tuning",
+        "conf": "ASPLOS'25",
+        "presenter": "Weilong Wang",
+        "facilitator": "Tianen Liu, Chengqing Zhao",
+        "date": "November 24, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-11-24-ASPLOS'25-Pruner.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-11-24-ASPLOS'25-Pruner"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/abs/10.1145/3676641.3716269"
+        }
+    },
+    {
+        "title": "AVA: Towards Agentic Video Analytics with Vision Language Models",
+        "conf": "NSDI'26",
+        "presenter": "Tianen Liu",
+        "facilitator": "Tianen Liu",
+        "date": "November 17, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-11-17-NSDI'26-AVA.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-11-17-NSDI'26-AVA"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2505.00254"
+        }
+    },
+    {
+        "title": "ReLoop: A Self-Correction Continual Learning Loop for Recommender Systems",
+        "conf": "SIGIR'22",
+        "presenter": "Lingfei Xu",
+        "facilitator": "Lingfei Xu",
+        "date": "November 10, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-11-10-SIGIR'22-ReLoop.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-11-10-SIGIR'22-ReLoop"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2204.11165"
+        }
+    },
+    {
+        "title": "AutoDroid-V2: Boosting SLM-based GUI Agents via Code Generation",
+        "conf": "MobiSys'25",
+        "presenter": "Chuanhua Fan",
+        "facilitator": "Chuanhua Fan",
+        "date": "November 3, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-11-03-MobiSys'25-AutoDroid-V2.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-11-03-MobiSys'25-AutoDroid-V2"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2412.18116"
+        }
+    },
+    {
+        "title": "WLB-LLM: Workload-Balanced 4D Parallelism for Large Language Model Training",
+        "conf": "OSDI'25",
+        "presenter": "Yi Liu",
+        "facilitator": "Yi Liu",
+        "date": "October 27, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-10-27-OSDI'25-WLB_LLM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-10-27-OSDI'25-WLB_LLM"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2503.17924"
+        }
+    },
+    {
+        "title": "Ubiquitous memory augmentation via mobile multimodal embedding system",
+        "conf": "Nature'25",
+        "presenter": "Yuankun Feng",
+        "facilitator": "Yuankun Feng",
+        "date": "October 20, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-10-20-NatureComm'25-Reminisce.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-10-20-NatureComm'25-Reminisce"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.nature.com/articles/s41467-025-60802-5"
+        }
+    },
+    {
+        "title": "Unlocking ECMP Programmability for Precise Traffic Control",
+        "conf": "NSDI'25",
+        "presenter": "Junan Lu",
+        "facilitator": "Yujie Chen",
+        "date": "October 13, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/kfgFZEGjkz4g"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-10-13-NSDI'25-ECMP_Program.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-10-13-NSDI'25-ECMP_Program"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/conference/nsdi25/presentation/liu-yadong"
+        }
+    },
+    {
+        "title": "White-Boxing RDMA with Packet-Granular Software Control",
+        "conf": "NSDI'25",
+        "presenter": "Kai Huang",
+        "facilitator": "Yujie Chen",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-NSDI'25-SCR.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NSDI'25-SCR"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.5555/3767955.3767978"
+        }
+    },
+    {
+        "title": "AutoCCL: Automated Collective Communication Tuning for Accelerating Distributed and Parallel DNN Training",
+        "conf": "NSDI'25",
+        "presenter": "Yujie Chen",
+        "facilitator": "Yujie Chen",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-NSDI'25-AutoCCL.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NSDI'25-AutoCCL"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/conference/nsdi25/presentation/xu-guanbin"
+        }
+    },
+    {
+        "title": "rStar-Math: Small LLMs Can Master Math Reasoning with Self-Evolved Deep Thinking",
+        "conf": "ICML'25",
+        "presenter": "Zhaonian Wang",
+        "facilitator": "Yitao Wang",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-ICML'25-rStar-Math.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-ICML'25-rStar-Math"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2501.04519"
+        }
+    },
+    {
+        "title": "Diffusion Language Model",
+        "conf": "None",
+        "presenter": "Zikang Chen",
+        "facilitator": "Yitao Wang",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-Diffuison-Language-Model.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-Diffuison-Language-Model"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": ""
+        }
+    },
+    {
+        "title": "Memory OS of AI Agent",
+        "conf": "EMNLP'25",
+        "presenter": "Haoran Ma",
+        "facilitator": "Yitao Wang",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-EMNLP'25-MemoryOS.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-EMNLP'25-MemoryOS"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2506.06326"
+        }
+    },
+    {
+        "title": "Supporting Our AI Overlords: Redesigning Data Systems to be Agent-First",
+        "conf": "SAA'25",
+        "presenter": "Fanglei Shu",
+        "facilitator": "Yitao Wang",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-SAA'25-DataSystems.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-SAA'25-DataSystems"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2509.00997"
+        }
+    },
+    {
+        "title": "Memp: Exploring Agent Procedural Memory",
+        "conf": "arXiv'25",
+        "presenter": "Yitao Wang",
+        "facilitator": "Yitao Wang",
+        "date": "September 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/jnCsoetqEZTS"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-arXiv'25-Memp.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-arXiv'25-Memp"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2508.06433"
+        }
+    },
+    {
+        "title": "AlphaEvolve: A coding agent for scientific and algorithmic discovery",
+        "conf": "Google DeepMind",
+        "presenter": "Lili Pan",
+        "facilitator": "Jiawei Liu",
+        "date": "September 20, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-Google'25-AlphaEvolve.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-Google'25-AlphaEvolve"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2506.13131"
+        }
+    },
+    {
+        "title": "RAP: Retrieval-Augmented Planning with Contextual Memory for Multimodal LLM Agents",
+        "conf": "NeurIPS'24",
+        "presenter": "Xingcai Zhang",
+        "facilitator": "Jiawei Liu",
+        "date": "September 20, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-NeurIPS'24-RAP.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-NeurIPS'24-RAP"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2402.03610"
+        }
+    },
+    {
+        "title": "CMT: A Memory Compression Method for Continual Knowledge Learning of Large Language Models",
+        "conf": "AAAI'25",
+        "presenter": "Jiawei Liu",
+        "facilitator": "Jiawei Liu",
+        "date": "September 20, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/LeQ6QPRSYeFJ"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-20-AAAI'25-CMT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-20-AAAI'25-CMT"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2412.07393"
+        }
+    },
+    {
+        "title": "Optimizing Large Language Model Training Using FP4 Quantization",
+        "conf": "ICML'25",
+        "presenter": "Yifan Hu",
+        "facilitator": "Botai Sun",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-ICML'25-FP4.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ICML'25-FP4"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2501.17116"
+        }
+    },
+    {
+        "title": "D2MoE: Dual Routing and Dynamic Scheduling for Efficient On-Device MoE-based LLM Serving",
+        "conf": "MobiCom'25",
+        "presenter": "Yunpeng Xu",
+        "facilitator": "Botai Sun",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-Mobicom'25-D2MoE.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-Mobicom'25-D2MoE"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2504.15299"
+        }
+    },
+    {
+        "title": "Nazar: Monitoring and Adapting ML Models on Mobile Devices",
+        "conf": "ASPLOS'25",
+        "presenter": "Botai Sun",
+        "facilitator": "Botai Sun",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-ASPLOS'25-Nazar.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ASPLOS'25-Nazar"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3669940.3707246"
+        }
+    },
+    {
+        "title": "AutoML-Agent: A Multi-Agent LLM Framework for Full-Pipeline AutoML",
+        "conf": "ICML'25",
+        "presenter": "Jinhan Xin",
+        "facilitator": "Weilong Wang",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-ICML'25-AutoML-Agent.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-ICML'25-AutoML-Agent"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2410.02958"
+        }
+    },
+    {
+        "title": "Bayesian Code Diffusion for Efficient Automatic Deep Learning Program Optimization",
+        "conf": "OSDI'25",
+        "presenter": "Hangshuai He",
+        "facilitator": "Weilong Wang",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-OSDI'25-Bayesian.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-OSDI'25-Bayesian"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.5555/3767901.3767918"
+        }
+    },
+    {
+        "title": "AutoMMLab: Automatically Generating Deployable Models from Language Instructions for Computer Vision Tasks",
+        "conf": "AAAI'25",
+        "presenter": "Weilong Wang",
+        "facilitator": "Weilong Wang",
+        "date": "September 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/oNQQ3Km2a61K"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-AAAI'25-AutoMMLab.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-AAAI'25-AutoMMLab"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2402.15351"
+        }
+    },
+    {
+        "title": "Adda: Towards Efficient in-Database Feature Generation via LLM-based Agents",
+        "conf": "SIGMOD'25",
+        "presenter": "Qingyang Song",
+        "facilitator": "Tianen Liu",
+        "date": "September 18, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-SIGMOD'25-Adda.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGMOD'25-Adda"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3725262"
+        }
+    },
+    {
+        "title": "E2ETune: End-to-End Knob Tuning via Fine-tuned Generative Language Model",
+        "conf": "VLDB'25",
+        "presenter": "Yuxiang Lu",
+        "facilitator": "Tianen Liu",
+        "date": "September 18, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-VLDB'25-E2ETune.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-VLDB'25-E2ETune"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2404.11581"
+        }
+    },
+    {
+        "title": "Intent-Driven Network Management with Multi-Agent LLMs: The Confucius Framework",
+        "conf": "SIGCOMM'25",
+        "presenter": "Minyuan Feng",
+        "facilitator": "Tianen Liu",
+        "date": "September 18, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-SIGCOMM'25-Confucius.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGCOMM'25-Confucius"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3718958.3750537"
+        }
+    },
+    {
+        "title": "𝜆-Tune: Harnessing Large Language Models for Automated Database System Tuning",
+        "conf": "SIGMOD'25",
+        "presenter": "Bin Dong",
+        "facilitator": "Tianen Liu",
+        "date": "September 18, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-SIGMOD'25-lambda-Tune.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-SIGMOD'25-lambda-Tune"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3709652"
+        }
+    },
+    {
+        "title": "ConfigBot: Adaptive Resource Allocation for Robot Applications in Dynamic Environments",
+        "conf": "IROS'25",
+        "presenter": "Tianen Liu",
+        "facilitator": "Tianen Liu",
+        "date": "September 18, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/EVNnZ9FYEeG8"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-18-IROS'25-ConfigBot.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-18-IROS'25-ConfigBot"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2501.10513"
+        }
+    },
+    {
+        "title": "HybriMoE: Hybrid CPU-GPU Scheduling and Cache Management for Efficient MoE Inference",
+        "conf": "DAC'25",
+        "presenter": "Changshuo Yao",
+        "facilitator": "Muhan Yuan, Hangshuai He",
+        "date": "September 11, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/GWm1Xp6OtLOM"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-12-DAC'25-HybriMoE.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-12-DAC'25-HybriMoE"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2504.05897"
+        }
+    },
+    {
+        "title": "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models",
+        "conf": "ICML'25",
+        "presenter": "Muhan Yuan",
+        "facilitator": "Muhan Yuan",
+        "date": "September 4, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/GWm1Xp6OtLOM"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-09-04-ICML'25-Revisiting_Chain_of_Thou.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-09-04-ICML'25-Revisiting_Chain_of_Thou"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/abs/2201.11903"
+        }
+    },
+    {
+        "title": "CogSys: Efficient and Scalable Neurosymbolic Cognition System via Algorithm-Hardware Co-Design",
+        "conf": "HPCA'25",
+        "presenter": "Qingyang Song",
+        "facilitator": "Qingyang Song",
+        "date": "July 25, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-07-25-HPCA'25-CogSys.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-07-25-HPCA'25-CogSys"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2503.01162"
+        }
+    },
+    {
+        "title": "A Workload-Aware DVFS Robust to Concurrent Tasks for Mobile Devices",
+        "conf": "MOBICOM'23",
+        "presenter": "Minyuan Feng",
+        "facilitator": "Haoran Ma, Hangshuai He",
+        "date": "July 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-07-18-MOBICOM'23-Gear.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-07-18-MOBICOM'23-Gear"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3570361.3592524"
+        }
+    },
+    {
+        "title": "ARIA: Optimizing Vision Foundation Model Inference on Heterogeneous Mobile Processors for Augmented Reality",
+        "conf": "MobiSys'25",
+        "presenter": "Haoran Ma",
+        "facilitator": "Lili Pan, Minyuan Feng",
+        "date": "July 11, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-07-11-MobiSys'25-ARIA.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-07-11-MobiSys'25-ARIA"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://mobed.yonsei.ac.kr/mobed_pages/pdf/aria-mobisys25.pdf"
+        }
+    },
+    {
+        "title": "GPIoT: Tailoring Small Language Models for IoT Program Synthesis and Development",
+        "conf": "SENSYS'25",
+        "presenter": "Lili Pan",
+        "facilitator": "Kai Huang, Haoran Ma",
+        "date": "JULY 4, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-07-04-Sensys'25-GPIoT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-07-04-Sensys'25-GPIoT"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3715014.3722064"
+        }
+    },
+    {
+        "title": "Optimizing generative AI by backpropagating language model feedback",
+        "conf": "Nature'25",
+        "presenter": "Xingcai Zhang",
+        "facilitator": "Yujie Chen, Bing Dong",
+        "date": "JUNE 20, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-06-20-Nature'25-TextGrad.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-06-20-Nature'25-TextGrad"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.nature.com/articles/s41586-025-08661-4"
+        }
+    },
+    {
+        "title": "TaskSense: A Translation-like Approach for Tasking HeterogeneousSensor Systems with LLMs",
+        "conf": "SenSys'25",
+        "presenter": "Bing Dong",
+        "facilitator": "Yitao Wang, Xingcai Zhang",
+        "date": "June 13, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-06-13-SenSys'25-TaskSense.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-06-13-SenSys'25-TaskSense"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3715014.3722070"
+        }
+    },
+    {
+        "title": "Punica: Multi-Tenant LoRA Serving",
+        "conf": "MLSys'24",
+        "presenter": "Kai Huang",
+        "facilitator": "Changshuo Yao, Lili Pan",
+        "date": "June 6, 2025",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-06-06-MLSys'24-Punica.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-06-06-MLSys'24-Punica"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "http://arxiv.org/pdf/2310.18547v1"
+        }
+    },
+    {
+        "title": "SimAI: Unifying Architecture Design and Performance Tuning for Large-Scale  Large Language Model Training with Scalability and Precision",
+        "conf": "NSDI'25",
+        "presenter": "Botai Sun",
+        "facilitator": "Yujie Chen, Changshuo Yao",
+        "date": "May 30, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-30-NDSI'25-SimAI.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-30-NDSI'25-SimAI"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/system/files/nsdi25-wang-xizheng-simai.pdf"
+        }
+    },
+    {
+        "title": "CA-LoRA: Adapting Existing LoRA for Compressed LLMs to Enable Efficient Multi-Tasking on Personal Devices",
+        "conf": "COLM'24",
+        "presenter": "Junan Lu",
+        "facilitator": "Yi Liu, Junan Lu",
+        "date": "May 23, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-23-COLM'24-CA-LoRA.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-23-COLM'24-CA-LoRA"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "http://arxiv.org/pdf/2307.07705v3"
+        }
+    },
+    {
+        "title": "SpotServe: Serving Generative Large Language Models on Preemptible Instances",
+        "conf": "ASPLOS'24",
+        "presenter": "Yi Liu",
+        "facilitator": "Yi Liu, Junan Lu",
+        "date": "May 23, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-23-ASPLOS'24-SpotServe.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-23-ASPLOS'24-SpotServe"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2311.15566"
+        }
+    },
+    {
+        "title": "LoongServe: Efficiently Serving Long-Context Large Language Models with Elastic Sequence Parallelism",
+        "conf": "SOSP'24",
+        "presenter": "Yifan Hu",
+        "facilitator": "Yunpeng Xu, Yifan Hu",
+        "date": "May 16, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-16-SOSP'24-LoongServe.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-16-SOSP'24-LoongServe"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2404.09526v2"
+        }
+    },
+    {
+        "title": "Proteus: A High-Throughput Inference-Serving System with Accuracy Scaling",
+        "conf": "ASPLOS'24",
+        "presenter": "Yunpeng Xu",
+        "facilitator": "Yunpeng Xu, Yifan Hu",
+        "date": "May 16, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-16-ASPLOS'24-Proteus.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-16-ASPLOS'24-Proteus"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://groups.cs.umass.edu/ramesh/wp-content/uploads/sites/3/2023/09/ljWiUS-asplos24spring-final29.pdf"
+        }
+    },
+    {
+        "title": "Characterization of Large Language Model Development in theDatacenter",
+        "conf": "NSDI'24",
+        "presenter": "Zhaonian Wang",
+        "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
+        "date": "May 9, 2025",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-09-NSDI'24-Characterization_of_LLM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-09-NSDI'24-Characterization_of_LLM"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/system/files/nsdi24-hu.pdf"
+        }
+    },
+    {
+        "title": "From Exploration to Mastery: Enabling LLMs to Master Tools via Self-Driven Interactions",
+        "conf": "ICLR'25",
+        "presenter": "Jinhan Xin",
+        "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
+        "date": "May 9, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-09-ICLR'25-From_Exploration_to_Mastery.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-09-ICLR'25-From_Exploration_to_Mastery"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2410.08197"
+        }
+    },
+    {
+        "title": "Autothrottle: A Practical Bi-Level Approach to Resource Management for SLO-Targeted Microservices",
+        "conf": "NSDI'24",
+        "presenter": "Chuanhua Fan",
+        "facilitator": "Chuanhua Fan, Jinhan Xin, Zhaonian Wang",
+        "date": "May 9, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-05-09-NSDI'24-Autothrottle.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-05-09-NSDI'24-Autothrottle"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/system/files/nsdi24-wang-zibo.pdf"
+        }
+    },
+    {
+        "title": "INFERCEPT:Efficient Intercept Support for Augmented Large Language Model Inference",
+        "conf": "ICML'24",
+        "presenter": "Zikang Chen",
+        "facilitator": "Yuankun Feng, Zikang Chen",
+        "date": "April 25,2025",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-04-25-ICML'24-INFERCEPT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-04-25-ICML'24-INFERCEPT"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/pdf/2402.01869"
+        }
+    },
+    {
+        "title": "LLM-Pruner: On the Structural Pruning of Large Language Models",
+        "conf": "NeurIPS'23",
+        "presenter": "Yuankun Feng",
+        "facilitator": "Yuankun Feng, Zikang Chen",
+        "date": "April 25,2025",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-04-25-NeurIPS'23-LLM-Pruner.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-04-25-NeurIPS'23-LLM-Pruner"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://proceedings.neurips.cc/paper_files/paper/2023/file/44956951349095f74492a5471128a7e0-Paper-Conference.pdf"
+        }
+    },
+    {
+        "title": "Parcae: Proactive, Liveput-Optimized DNN Training on Preemptible Instances",
+        "conf": "NSDI'24",
+        "presenter": "Yujie Chen",
+        "facilitator": "Botai Sun, Xingcai Zhang",
+        "date": "April 18, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-04-18-NSDI'24-Parcae.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-04-18-NSDI'24-Parcae"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://www.usenix.org/system/files/nsdi24-duan.pdf"
+        }
+    },
+    {
+        "title": "8-bit Transformer Inference and Fine-tuning for Edge Accelerators",
+        "conf": "ASPLOS'24",
+        "presenter": "Changshuo Yao",
+        "facilitator": "Botai Sun, Kai Huang",
+        "date": "April 11, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-04-11-ASPLOS'24-8bit_Transformer.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-04-11-ASPLOS'24-8bit_Transformer"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://dl.acm.org/doi/10.1145/3620666.3651368"
+        }
+    },
+    {
+        "title": "GPTuner: A Manual-Reading Database Tuning System via  GPT-Guided Bayesian Optimization",
+        "conf": "VLDB'24",
+        "presenter": "Yuxiang Lu",
+        "facilitator": "Hangshuai He, Songtao Lu",
+        "date": "March 21, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-03-21-VLDB'24-GPTuner.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-03-21-VLDB'24-GPTuner"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "GPTuner: A Manual-Reading Database Tuning System via GPT-Guided Bayesian Optimization"
+        }
+    },
+    {
+        "title": "Enabling Tensor Language Model to Assist in Generating High-Performance Tensor Programs for Deep Learning",
+        "conf": "OSDI'24",
+        "presenter": "Hangshuai He",
+        "facilitator": "Minyuan Feng, Yuxiang Lu",
+        "date": "March 14, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/KkDxEzDhDn34"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-03-14-OSDI'24-Enabling.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-03-14-OSDI'24-Enabling"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/system/files/osdi24-zhai.pdf"
+        }
+    },
+    {
+        "title": "DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving",
+        "conf": "OSDI'24",
+        "presenter": "Yitao Wang",
+        "facilitator": "Fanglei Shu, Bing Dong",
+        "date": "March 7, 2025.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qvug5ylXPFkh"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-03-07-NDSI'24-distserve.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-03-07-NDSI'24-distserve"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/system/files/osdi24-zhong-yinmin.pdf"
+        }
+    },
+    {
+        "title": "ISOLATEGPT: An Execution Isolation  Architecture for LLM-Based Agentic Systems",
+        "conf": "NDSS'25",
+        "presenter": "Fanglei Shu",
+        "facilitator": "Yachen Wu, Yitao Wang",
+        "date": "February 28, 2025.",
+        "time": "2:30 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/3higw0fO3laq"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-02-28-NDSS'25-Isolategpt.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-02-28-NDSS'25-Isolategpt"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/pdf/2403.04960"
+        }
+    },
+    {
+        "title": "BumbleBee: Dynamic KV-Cache Streaming Submodular Summarization for Infinite-Context Transformers",
+        "conf": "COLM'24",
+        "presenter": "Yachen Wu",
+        "facilitator": "Jiawei Liu, Fanglei Shu",
+        "date": "January 16, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/3higw0fO3laq"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-01-16-COLM'24-BumbleBee.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-01-16-COLM'24-BumbleBee"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://openreview.net/pdf?id=8w0RApM5yG"
+        }
+    },
+    {
+        "title": "Modality Plug-and-Play: Runtime Modality Adaptation in LLM-Driven Autonomous Mobile Systems",
+        "conf": "MobiCom'25",
+        "presenter": "Jiawei Liu",
+        "facilitator": "Tianen Liu, Yachen Wu",
+        "date": "January 10, 2025.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/nzkCPK31Bcqx"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2025-01-10-MobiCom'25-Modality-Plug-and-Play.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2025-01-10-MobiCom'25-Modality-Plug-and-Play"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/pdf/2312.07886"
+        }
+    },
+    {
+        "title": "Perceptual-Centric Image Super-Resolution using Heterogeneous Processors on Mobile Devices",
+        "conf": "MobiCom'24",
+        "presenter": "Tianen Liu",
+        "facilitator": "Chengqing Zhao, Jiawei Liu",
+        "date": "December 27, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": ""
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-12-27-MobiCom'24-Super-Resolution.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-12-27-MobiCom'24-Super-Resolution"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://dl.acm.org/doi/10.1145/3636534.3690698"
+        }
+    },
+    {
+        "title": "Alps: An Adaptive Learning, Priority OS Scheduler for Serverless Function",
+        "conf": "ATC'24",
+        "presenter": "Chengqing Zhao",
+        "facilitator": "Weilong Wang, Tianen Liu",
+        "date": "December 20, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/nUErptQGpSPL"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-12-20-ATC'24-Alps.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-12-20-ATC'24-Alps"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/system/files/atc24-fu.pdf"
+        }
+    },
+    {
+        "title": "Can’t Be Late: Optimizing Spot Instance Savings under Deadlines",
+        "conf": "NSDI'24",
+        "presenter": "Weilong Wang",
+        "facilitator": "Tiange Xia, Chengqing Zhao",
+        "date": "December 20, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/nUErptQGpSPL"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-12-20-NSDI'24-SPOTWORK.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-12-20-NSDI'24-SPOTWORK"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/system/files/nsdi24-wu-zhanghao.pdf"
+        }
+    },
+    {
+        "title": "EDGE-LLM: Enabling Efficient Large Language Model Adaptation on Edge Devices via Layerwise Unified Compression and Adaptive Layer Tuning & Voting",
+        "conf": "DAC'24",
+        "presenter": "Tiange Xia",
+        "facilitator": "Weilong Wang, Muhan Yuan",
+        "date": "November 29, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/T6vST3H5tfBV"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-29-DAC'24-EDGELLM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-29-DAC'24-EDGELLM"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3649329.3658473"
+        }
+    },
+    {
+        "title": "WebVoyager: Building an End-to-End Web Agent with Large Multimodal Models",
+        "conf": "ACL'24",
+        "presenter": "Muhan Yuan",
+        "facilitator": "Lili Pan, Kai Huang",
+        "date": "November 22, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/COZdhdwGNJuc"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-22-ACL'24-WebVoyager.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-22-ACL'24-WebVoyager"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2401.13919"
+        }
+    },
+    {
+        "title": "Fast On-device LLM Inference with NPUs",
+        "conf": "ASPLOS'25",
+        "presenter": "Changshuo Yao",
+        "facilitator": "Chuanyou Li",
+        "date": "November 15, 2024.",
+        "time": "10:10 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/yehYWE3IKQaM"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-15-ASPLOS'25-FODLLM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-15-ASPLOS'25-FODLLM"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2407.05858"
+        }
+    },
+    {
+        "title": "NetLLM: Adapting Large Language Models for Networking",
+        "conf": "SIGCOMM'24",
+        "presenter": "Bin Dong",
+        "facilitator": "Borui Li",
+        "date": "November 15, 2024.",
+        "time": "9:30 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/yehYWE3IKQaM"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-15-SIGCOMM'24-NetLLM.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-15-SIGCOMM'24-NetLLM"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2402.02338"
+        }
+    },
+    {
+        "title": "Keep the Cost Down:A Review on Methods to Optimize LLM's KV Cache Consumption",
+        "conf": "CoLM'24",
+        "presenter": "Yachen Wu",
+        "facilitator": "Chuanyou Li",
+        "date": "November 10, 2024.",
+        "time": "5:30 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-CoLM'24-KVCache.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-CoLM'24-KVCache"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2407.18003"
+        }
+    },
+    {
+        "title": "ExeGPT: Constraint-Aware Resource Scheduling for LLM Inference",
+        "conf": "ASPLOS'24",
+        "presenter": "Songtao Lu",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "4:55 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-ASPLOS'24-ExeGPT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-ASPLOS'24-ExeGPT"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2404.07947"
+        }
+    },
+    {
+        "title": "AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversations",
+        "conf": "COLM'24",
+        "presenter": "Fanglei Shu",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "4:20 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-COLM'24-AutoGen.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-COLM'24-AutoGen"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2308.08155"
+        }
+    },
+    {
+        "title": "HuggingGPT: Solving AI Tasks with ChatGPT and its Friends in Hugging Face",
+        "conf": "NeurIPS'23",
+        "presenter": "Xingcai Zhang",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "4:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-ACL'24-AgentPro.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-ACL'24-AgentPro"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/pdf/2303.17580"
+        }
+    },
+    {
+        "title": "Agent-Pro: Learning to Evolve via Policy-Level Reflection and Optimization",
+        "conf": "ACL'24",
+        "presenter": "Xingcai Zhang",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "3:45 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-ACL'24-AgentPro.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-ACL'24-AgentPro"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2402.17574"
+        }
+    },
+    {
+        "title": "A Language Agent for Autonomous Driving",
+        "conf": "COLM'24",
+        "presenter": "Hangshuai He",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "3:10 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-COLM'24-LAFAD.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-COLM'24-LAFAD"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/abs/2311.10813"
+        }
+    },
+    {
+        "title": "ChatIoT: Zero-code Generation of Trigger-action Based IoT Programs",
+        "conf": "Ubicomp'24",
+        "presenter": "Lili Pan",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "2:35 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-Ubicomp'24-ChatIoT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-Ubicomp'24-ChatIoT"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://dl.acm.org/doi/abs/10.1145/3678585"
+        }
+    },
+    {
+        "title": "Hairpin: Rethinking Packet Loss Recovery in Edge-based Interactive Video Streaming",
+        "conf": "NSDI'24",
+        "presenter": "Botai Sun",
+        "facilitator": "Chuanyou Li",
+        "date": "November 10, 2024.",
+        "time": "2:00 p.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-NSDI'24-Hairpin.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-NSDI'24-Hairpin"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/meng"
+        }
+    },
+    {
+        "title": "SLNet: A Spectrogram Learning Neural Network for Deep Wireless Sensing",
+        "conf": "NSDI'23",
+        "presenter": "Yujie Chen",
+        "facilitator": "Chuanyou Li",
+        "date": "November 10, 2024.",
+        "time": "10:55 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-NSDI'23-SLNet.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-NSDI'23-SLNet"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi23/presentation/yang-zheng"
+        }
+    },
+    {
+        "title": "INVAR: Inversion Aware Resource Provisioning and Workload Scheduling for Edge Computing",
+        "conf": "INFOCOM'24",
+        "presenter": "Kai Huang",
+        "facilitator": "Chuanyou Li",
+        "date": "November 10, 2024.",
+        "time": "10:20 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-INFOCOM'24-INVAR.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-INFOCOM'24-INVAR"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://ieeexplore.ieee.org/document/10621417"
+        }
+    },
+    {
+        "title": "Apparate: Rethinking Early Exits to Tame Latency-Throughput Tensions in ML Serving",
+        "conf": "SOSP'24",
+        "presenter": "Minyuan Feng",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "9:45 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-SOSP'24-Apparate.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-SOSP'24-Apparate"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://arxiv.org/pdf/2312.05385"
+        }
+    },
+    {
+        "title": "FlexNN: Efficient and Adaptive DNN Inference on Memory-Constrained Edge Devices",
+        "conf": "MobiCom'24",
+        "presenter": "Yuxiang Lu",
+        "facilitator": "Borui Li",
+        "date": "November 10, 2024.",
+        "time": "9:10 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/5y7V5wQ9vMyI"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-11-10-MobiCom'24-FlexNN.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-11-10-MobiCom'24-FlexNN"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://dl.acm.org/doi/pdf/10.1145/3636534.3649391"
+        }
+    },
+    {
+        "title": "LitePred: Transferable and Scalable Latency Prediction for Hardware-Aware Neural Architecture Search",
+        "conf": "NSDI'24",
+        "presenter": "Changshuo Yao",
+        "facilitator": "Chuanyou Li",
+        "date": "July 25, 2024.",
+        "time": "7:00 p.m.",
+        "location": "Room CS @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/8CGH1csJOVp4"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-07-25-NSDI'24-LitePred.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-07-25-NSDI'24-LitePred"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/feng-chengquan"
+        }
+    },
+    {
+        "title": "CASSINI: Network-Aware Job Scheduling in Machine Learning Clusters",
+        "conf": "NSDI'24",
+        "presenter": "Botai Sun",
+        "facilitator": "Chuanyou Li",
+        "date": "July 18, 2024.",
+        "time": "7:00 p.m.",
+        "location": "Room CS @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/RfNf0JCHCja7"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-07-18-NSDI'24-CASSINI.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-07-18-NSDI'24-CASSINI"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/rajasekaran"
+        }
+    },
+    {
+        "title": "MadEye: Boosting Live Video Analytics Accuracy with Adaptive Camera Configurations",
+        "conf": "NSDI'24",
+        "presenter": "Yujie Chen",
+        "facilitator": "Chuanyou Li",
+        "date": "July 11, 2024.",
+        "time": "8:00 p.m.",
+        "location": "Room CS @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/1ytQw5VuAPv0"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-07-11-NSDI'24-MadEye.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-07-11-NSDI'24-MadEye"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/wong"
+        }
+    },
+    {
+        "title": "Vulcan: Automatic Query Planning for Live ML Analytics",
+        "conf": "NSDI'24",
+        "presenter": "Minyuan Feng",
+        "facilitator": "Borui Li",
+        "date": "July 11, 2024.",
+        "time": "7:00 p.m.",
+        "location": "Room CS @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/1ytQw5VuAPv0"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-07-11-NSDI'24-Vulcan.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-07-11-NSDI'24-Vulcan"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/zhang-yiwen"
+        }
+    },
+    {
+        "title": "Accelerating Neural Recommendation Training with Embedding Scheduling",
+        "conf": "NSDI'24",
+        "presenter": "Kai Huang",
+        "facilitator": "Chuanyou Li",
+        "date": "July 4, 2024.",
+        "time": "7:00 p.m.",
+        "location": "Room CS @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/cGqoEdimqm2W"
+            },
+            {
+                "title": "Slides",
+                "url": "/slides/2024-07-04-NSDI'24-ANRT.pdf"
+            },
+            {
+                "title": "Videos",
+                "url": "http://10.201.0.220:8099/?meeting=2024-07-04-NSDI'24-ANRT"
+            }
+        ],
+        "dblp": {
+            "source": "DBLP",
+            "url": "https://www.usenix.org/conference/nsdi24/presentation/zeng"
+        }
     }
-}
 ]

--- a/scripts/sync-feishu.js
+++ b/scripts/sync-feishu.js
@@ -14,9 +14,20 @@ const DEFAULT_CONFIG = {
     tableId: "tblrVI06ls9biJoA",
     viewId: "vew63l2LQh",
     outputPath: "schedules.js",
-    defaultTime: "9:30 a.m.",
+    slidesDir: "slides",
+    defaultTime: "11:00 a.m.",
     defaultLocation: "Room ARTS1021 @ SEU & Online",
     defaultDblpSource: "website",
+    confAliases: {
+        "The ACM Web Conference 2026": "WWW'26",
+        "ACM Web Conference 2026": "WWW'26",
+        "The Web Conference 2026": "WWW'26"
+    },
+    nameAliases: {
+        "秦子昂": "Ziang Qin",
+        "施晨晖": "Chenhui Shi",
+        "刘孟玄": "Mengxuan Liu",
+    },
     fieldAliases: {
         title: ["title", "paper title", "topic", "name", "论文标题", "论文题目", "题目", "标题", "名称"],
         conf: ["conf", "conference", "venue", "会议", "会议名称", "发表会议", "来源会议"],
@@ -170,20 +181,26 @@ async function main() {
     const config = loadConfig();
     const token = await getTenantAccessToken(appId, appSecret);
     const records = await listBitableRecords(token, config);
-    const schedules = records
-        .map((record, index) => toSchedule(record, config, index))
-        .filter(Boolean);
-
-    const { upcoming, history } = splitSchedules(schedules);
     const outputPath = path.resolve(ROOT_DIR, config.outputPath);
     const oldOutput = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, "utf8") : "";
     const existingData = readExistingSchedules(oldOutput);
+    const schedules = (
+        await Promise.all(
+            records.map((record, index) =>
+                toSchedule(record, config, index, {
+                    token,
+                    dryRun: args.has("--dry-run")
+                })
+            )
+        )
+    ).filter(Boolean);
+    const { upcoming, history } = splitSchedules(schedules, { existingHistory: existingData.schedules });
     const replaceAll = args.has("--replace-all");
-    const nextUpcoming = upcoming;
+    const nextUpcoming = mergeUpcomingSchedules(existingData.upcoming, upcoming);
     const nextHistory = replaceAll ? history : mergeSchedules(existingData.schedules, history, nextUpcoming);
-    const output = renderSchedulesJs(nextUpcoming, nextHistory);
     const nextTotal = nextUpcoming.length + nextHistory.length;
     const existingTotal = existingData.upcoming.length + existingData.schedules.length;
+    const output = renderSchedulesJs(nextUpcoming, nextHistory);
 
     if (args.has("--dry-run")) {
         console.log(`[feishu-sync] fetched ${records.length} records`);
@@ -208,14 +225,16 @@ async function main() {
         );
     }
 
+    await downloadReferencedSlides([...nextUpcoming, ...nextHistory], config, token);
+
     if (normalizeNewlines(oldOutput) === normalizeNewlines(output)) {
-        console.log(`[feishu-sync] no changes. upcoming: ${upcoming.length}, schedules: ${history.length}`);
+        console.log(`[feishu-sync] no changes. output: upcoming ${nextUpcoming.length}, schedules ${nextHistory.length}`);
         return;
     }
 
     fs.writeFileSync(outputPath, output, "utf8");
     console.log(`[feishu-sync] updated ${path.relative(ROOT_DIR, outputPath)}`);
-    console.log(`[feishu-sync] upcoming: ${upcoming.length}, schedules: ${history.length}`);
+    console.log(`[feishu-sync] output: upcoming ${nextUpcoming.length}, schedules ${nextHistory.length}`);
 }
 
 function loadLocalEnv(filePath) {
@@ -270,6 +289,14 @@ function loadConfig() {
     return applyEnvOverrides({
         ...DEFAULT_CONFIG,
         ...userConfig,
+        confAliases: {
+            ...DEFAULT_CONFIG.confAliases,
+            ...(userConfig.confAliases || {})
+        },
+        nameAliases: {
+            ...DEFAULT_CONFIG.nameAliases,
+            ...(userConfig.nameAliases || {})
+        },
         fieldAliases: {
             ...DEFAULT_CONFIG.fieldAliases,
             ...(userConfig.fieldAliases || {})
@@ -352,7 +379,7 @@ async function fetchJson(url, options = {}) {
     return data;
 }
 
-function toSchedule(record, config, sourceIndex) {
+async function toSchedule(record, config, sourceIndex, options = {}) {
     const fields = record.fields || {};
     const hidden = readField(fields, config.fieldAliases.hidden);
 
@@ -361,8 +388,8 @@ function toSchedule(record, config, sourceIndex) {
     }
 
     const title = readField(fields, config.fieldAliases.title);
-    const conf = readField(fields, config.fieldAliases.conf);
-    const presenter = readField(fields, config.fieldAliases.presenter);
+    const conf = normalizeConfName(readField(fields, config.fieldAliases.conf), config);
+    const presenter = normalizePersonNames(readField(fields, config.fieldAliases.presenter), config);
 
     if (!title || !conf || !presenter) {
         const availableFields = Object.keys(fields).join(", ");
@@ -376,18 +403,21 @@ function toSchedule(record, config, sourceIndex) {
     const timeValue = rawField(fields, config.fieldAliases.time);
     const section = readField(fields, config.fieldAliases.section).toLowerCase();
     const tencentMeetingUrl = readField(fields, config.fieldAliases.tencentMeetingUrl, { preferUrl: true });
-    const slidesUrl = readField(fields, config.fieldAliases.slidesUrl, { preferUrl: true });
+    const slidesValue = rawField(fields, config.fieldAliases.slidesUrl);
     const videoUrl = readField(fields, config.fieldAliases.videoUrl, { preferUrl: true });
     const paperUrl = readField(fields, config.fieldAliases.paperUrl, { preferUrl: true });
     const paperSource = readField(fields, config.fieldAliases.paperSource) || config.defaultDblpSource;
-    const sortDate = parseScheduleDateTime(dateValue, timeValue);
+    const displayTime = formatTimeValue(timeValue) || config.defaultTime;
+    const sortDate = parseScheduleDateTime(dateValue, displayTime);
+    const formattedDate = formatDateValue(dateValue);
+    const slidesInfo = resolveSlidesUrl(slidesValue, { title, conf, date: formattedDate }, config, options);
 
     const links = [];
     if (tencentMeetingUrl) {
         links.push({ title: "TencentMeeting", url: tencentMeetingUrl });
     }
-    if (slidesUrl) {
-        links.push({ title: "Slides", url: slidesUrl });
+    if (slidesInfo.url) {
+        links.push({ title: "Slides", url: slidesInfo.url });
     }
     if (videoUrl) {
         links.push({ title: "Videos", url: videoUrl });
@@ -397,9 +427,9 @@ function toSchedule(record, config, sourceIndex) {
         title,
         conf,
         presenter,
-        facilitator: readField(fields, config.fieldAliases.facilitator),
-        date: formatDateValue(dateValue),
-        time: formatTimeValue(timeValue) || config.defaultTime,
+        facilitator: "",
+        date: formattedDate,
+        time: displayTime,
         location: readField(fields, config.fieldAliases.location) || config.defaultLocation,
         links
     };
@@ -423,6 +453,10 @@ function toSchedule(record, config, sourceIndex) {
         _sourceIndex: {
             value: sourceIndex,
             enumerable: false
+        },
+        _slidesAttachment: {
+            value: slidesInfo.attachment,
+            enumerable: false
         }
     });
 
@@ -436,6 +470,131 @@ function rawField(fields, aliases) {
 
 function readField(fields, aliases, options = {}) {
     return normalizeFieldValue(rawField(fields, aliases), options);
+}
+
+async function downloadReferencedSlides(schedules, config, token) {
+    const seen = new Set();
+    for (const schedule of schedules) {
+        const attachment = schedule._slidesAttachment;
+        if (!attachment || seen.has(attachment.fileToken)) {
+            continue;
+        }
+        seen.add(attachment.fileToken);
+        await downloadFeishuMedia(attachment.fileToken, attachment.filePath, token);
+    }
+}
+
+async function downloadFeishuMedia(fileToken, filePath, token) {
+    if (fs.existsSync(filePath)) {
+        return;
+    }
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const url = `https://open.feishu.cn/open-apis/drive/v1/medias/${encodeURIComponent(fileToken)}/download`;
+    const response = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
+    });
+
+    if (!response.ok) {
+        const message = await response.text();
+        throw new Error(`Failed to download slides ${path.basename(filePath)}: ${message.slice(0, 300)}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(filePath, buffer);
+    console.log(`[feishu-sync] downloaded ${path.relative(ROOT_DIR, filePath)}`);
+}
+
+function resolveSlidesUrl(value, schedule, config) {
+    const existingUrl = normalizeFieldValue(value, { preferUrl: true });
+    const attachment = findFeishuAttachment(value);
+
+    if (!attachment || !attachment.file_token) {
+        return { url: existingUrl, attachment: null };
+    }
+
+    const slidesDir = config.slidesDir || "slides";
+    const fileName = sanitizeSlideFileName(attachment.name || buildSlideFileName(schedule, attachment));
+    const filePath = path.resolve(ROOT_DIR, slidesDir, fileName);
+    const publicPath = `/${[slidesDir.replace(/^\/+|\/+$/g, ""), fileName].filter(Boolean).join("/")}`;
+
+    return {
+        url: publicPath,
+        attachment: {
+            fileToken: attachment.file_token,
+            filePath
+        }
+    };
+}
+
+function findFeishuAttachment(value) {
+    if (!value) {
+        return null;
+    }
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const attachment = findFeishuAttachment(item);
+            if (attachment) {
+                return attachment;
+            }
+        }
+        return null;
+    }
+    if (typeof value === "object") {
+        if (value.file_token) {
+            return value;
+        }
+        for (const nested of Object.values(value)) {
+            const attachment = findFeishuAttachment(nested);
+            if (attachment) {
+                return attachment;
+            }
+        }
+    }
+    return null;
+}
+
+function sanitizeSlideFileName(fileName) {
+    const sanitized = String(fileName || "")
+        .trim()
+        .replace(/[<>:"/\\|?*\x00-\x1F]/g, "-")
+        .replace(/\s+/g, "_")
+        .replace(/-+/g, "-");
+
+    return sanitized || "slides.pdf";
+}
+
+function buildSlideFileName(schedule, attachment) {
+    const date = parseDateValue(schedule.date);
+    const datePart = date
+        ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`
+        : "slides";
+    const titlePart = normalizeFilePart(schedule.title).slice(0, 60) || "presentation";
+    const confPart = normalizeFilePart(schedule.conf).slice(0, 20);
+    const extension = extensionFromAttachment(attachment);
+
+    return [datePart, confPart, titlePart].filter(Boolean).join("-") + extension;
+}
+
+function normalizeFilePart(value) {
+    return String(value || "")
+        .trim()
+        .replace(/[^A-Za-z0-9'._-]+/g, "_")
+        .replace(/_+/g, "_")
+        .replace(/^_+|_+$/g, "");
+}
+
+function extensionFromAttachment(attachment) {
+    const nameExtension = path.extname(attachment.name || "");
+    if (nameExtension) {
+        return nameExtension;
+    }
+    if (attachment.type === "application/pdf") {
+        return ".pdf";
+    }
+    return "";
 }
 
 function resolveFieldKey(fields, aliases = []) {
@@ -508,24 +667,61 @@ function normalizeFieldValue(value, options = {}) {
     return "";
 }
 
+function normalizePersonNames(value, config) {
+    const normalized = normalizeFieldValue(value);
+    if (!normalized) {
+        return "";
+    }
+
+    const aliases = config.nameAliases || {};
+    return normalized
+        .split(/\s*[,，、;；]\s*/)
+        .filter(Boolean)
+        .map((name) => aliases[name] || name)
+        .join(", ");
+}
+
+function normalizeConfName(value, config) {
+    const normalized = normalizeFieldValue(value);
+    if (!normalized) {
+        return "";
+    }
+
+    return (config.confAliases || {})[normalized] || normalized;
+}
+
 function isTruthyHidden(value) {
     return ["1", "true", "yes", "y", "hidden", "hide", "skip", "disabled", "是", "隐藏", "跳过", "不展示"].includes(
         String(value || "").trim().toLowerCase()
     );
 }
 
-function splitSchedules(schedules) {
+function splitSchedules(schedules, options = {}) {
     const ordered = schedules.slice().sort(compareScheduleDesc);
-    const latest = ordered[0];
-    const upcoming = latest ? [latest] : [];
-    const latestKey = latest ? scheduleKey(latest) : "";
-    const history = ordered.filter((schedule) => scheduleKey(schedule) !== latestKey);
+    const existingHistoryKeys = new Set((options.existingHistory || []).map(scheduleKey));
+    const nowTime = options.now instanceof Date ? options.now.getTime() : Date.now();
+    const upcoming = ordered
+        .filter((schedule) => isFutureSchedule(schedule, nowTime))
+        .filter((schedule) => !existingHistoryKeys.has(scheduleKey(schedule)))
+        .sort(compareScheduleAsc)
+        .slice(0, 1);
+    const upcomingKeys = new Set(upcoming.map(scheduleKey));
+    const history = ordered.filter((schedule) => !upcomingKeys.has(scheduleKey(schedule)));
 
     return { upcoming, history };
 }
 
 function compareScheduleDesc(a, b) {
     return (b._sortTime || 0) - (a._sortTime || 0) || (b._sourceIndex || 0) - (a._sourceIndex || 0);
+}
+
+function compareScheduleAsc(a, b) {
+    return (a._sortTime || 0) - (b._sortTime || 0) || (a._sourceIndex || 0) - (b._sourceIndex || 0);
+}
+
+function isFutureSchedule(schedule, nowTime) {
+    const scheduleTime = schedule._sortTime || parseScheduleDateTime(schedule.date, schedule.time)?.getTime() || 0;
+    return scheduleTime >= nowTime;
 }
 
 function formatDateValue(value) {
@@ -671,12 +867,16 @@ function mergeSchedules(existingHistory, incomingHistory, incomingUpcoming) {
     const byKey = new Map();
 
     for (const schedule of existingHistory) {
-        if (!upcomingKeys.has(scheduleKey(schedule))) {
-            byKey.set(scheduleKey(schedule), schedule);
+        const key = scheduleKey(schedule);
+        if (!upcomingKeys.has(key) && !byKey.has(key)) {
+            byKey.set(key, schedule);
         }
     }
     for (const schedule of incomingHistory) {
-        byKey.set(scheduleKey(schedule), schedule);
+        const key = scheduleKey(schedule);
+        if (!byKey.has(key)) {
+            byKey.set(key, schedule);
+        }
     }
 
     return Array.from(byKey.values()).sort((a, b) => {
@@ -686,8 +886,26 @@ function mergeSchedules(existingHistory, incomingHistory, incomingUpcoming) {
     });
 }
 
+function mergeUpcomingSchedules(existingUpcoming, incomingUpcoming) {
+    const existingByKey = new Map((existingUpcoming || []).map((schedule) => [scheduleKey(schedule), schedule]));
+    return incomingUpcoming.map((schedule) => mergeMissingScheduleFields(existingByKey.get(scheduleKey(schedule)), schedule));
+}
+
+function mergeMissingScheduleFields(existing, incoming) {
+    if (!existing) {
+        return incoming;
+    }
+
+    return {
+        ...incoming,
+        facilitator: incoming.facilitator || existing.facilitator || "",
+        location: incoming.location || existing.location || "",
+        time: incoming.time || existing.time || ""
+    };
+}
+
 function scheduleKey(schedule) {
-    return [schedule.title, schedule.conf, schedule.date, schedule.presenter].map(normalizeKey).join("|");
+    return [schedule.title, schedule.conf, schedule.date].map(normalizeKey).join("|");
 }
 
 function printHelp() {


### PR DESCRIPTION
- Add June 8, 2026 EdgeGen upcoming schedule
- Add EdgeGen slides PDF
- Update post-April 7 meeting time to 11:00 a.m.
- Improve Feishu sync logic:
  - choose upcoming by future schedule time
  - avoid duplicate historical entries
  - download Feishu slide attachments into slides/
  - normalize conference and presenter names
  - keep facilitator manually maintained in schedules.js
- Update Feishu sync documentation