### PR TITLE
update schedule for 2026-06-15

### DIFF
--- a/docs/feishu-sync.md
+++ b/docs/feishu-sync.md
@@ -13,7 +13,7 @@ npm run sync:feishu
 脚本会先读取仓库现有的 `schedules.js` 和飞书表格里的有效记录，再按「组会汇报时间」判断记录位置：
 
 - 只有「组会汇报时间」还没到、并且尚未存在于历史 `schedules` 中的记录，才会进入 `upcoming_schedules`
-- 如果有多条未来记录，时间最近的一条写入 `upcoming_schedules`
+- 如果有多条未来记录，时间最近的一批写入 `upcoming_schedules`；同一时间有多篇报告时会一起展示
 - 已经过期的飞书记录会合并进历史 `schedules`
 - 仓库里已有的历史 `schedules` 会继续保留
 - 如果同一条历史记录已经存在，默认保留仓库里的版本，避免飞书记录重复写入历史

--- a/schedules.js
+++ b/schedules.js
@@ -1,5 +1,46 @@
 var upcoming_schedules = [
     {
+        "title": "EmbodiSkill: Skill-Aware Reflection for Self-Evolving Embodied Agents",
+        "conf": "arXiv'26",
+        "presenter": "Qingyang Song",
+        "facilitator": "",
+        "date": "June 15, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qmvxYw51Cnez"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/abs/2605.10332"
+        }
+    },
+    {
+        "title": "δ-mem: Efficient Online Memory for Large Language Models",
+        "conf": "arXiv'26",
+        "presenter": "Qingyang Song",
+        "facilitator": "",
+        "date": "June 15, 2026.",
+        "time": "11:00 a.m.",
+        "location": "Room ARTS1021 @ SEU & Online",
+        "links": [
+            {
+                "title": "TencentMeeting",
+                "url": "https://meeting.tencent.com/dm/qmvxYw51Cnez"
+            }
+        ],
+        "dblp": {
+            "source": "website",
+            "url": "https://arxiv.org/abs/2605.12357"
+        }
+    }
+]
+
+var schedules = [
+    {
         "title": "EdgeGen: Efficient LLM-Empowered Model Generation with Quantization-Aware NAS",
         "conf": "WWW'26",
         "presenter": "Chenhui Shi",
@@ -21,10 +62,7 @@ var upcoming_schedules = [
             "source": "website",
             "url": "https://dl.acm.org/doi/10.1145/3774904.3792394"
         }
-    }
-]
-
-var schedules = [
+    },
     {
         "title": "A House United Within Itself: SLO-Awareness for On-Premises Containerized ML Inference Clusters via Faro",
         "conf": "Eurosys'25",

--- a/scripts/sync-feishu.js
+++ b/scripts/sync-feishu.js
@@ -27,6 +27,8 @@ const DEFAULT_CONFIG = {
         "秦子昂": "Ziang Qin",
         "施晨晖": "Chenhui Shi",
         "刘孟玄": "Mengxuan Liu",
+        "刘蒙玄": "Mengxuan Liu",
+        "宋青阳": "Qingyang Song"
     },
     fieldAliases: {
         title: ["title", "paper title", "topic", "name", "论文标题", "论文题目", "题目", "标题", "名称"],
@@ -197,7 +199,7 @@ async function main() {
     const { upcoming, history } = splitSchedules(schedules, { existingHistory: existingData.schedules });
     const replaceAll = args.has("--replace-all");
     const nextUpcoming = mergeUpcomingSchedules(existingData.upcoming, upcoming);
-    const nextHistory = replaceAll ? history : mergeSchedules(existingData.schedules, history, nextUpcoming);
+    const nextHistory = replaceAll ? history : mergeSchedules(existingData.schedules, history, nextUpcoming, existingData.upcoming);
     const nextTotal = nextUpcoming.length + nextHistory.length;
     const existingTotal = existingData.upcoming.length + existingData.schedules.length;
     const output = renderSchedulesJs(nextUpcoming, nextHistory);
@@ -698,13 +700,18 @@ function isTruthyHidden(value) {
 
 function splitSchedules(schedules, options = {}) {
     const ordered = schedules.slice().sort(compareScheduleDesc);
-    const existingHistoryKeys = new Set((options.existingHistory || []).map(scheduleKey));
     const nowTime = options.now instanceof Date ? options.now.getTime() : Date.now();
-    const upcoming = ordered
+    const existingHistoryKeys = new Set(
+        (options.existingHistory || [])
+            .filter((schedule) => !isFutureSchedule(schedule, nowTime))
+            .map(scheduleKey)
+    );
+    const future = ordered
         .filter((schedule) => isFutureSchedule(schedule, nowTime))
         .filter((schedule) => !existingHistoryKeys.has(scheduleKey(schedule)))
-        .sort(compareScheduleAsc)
-        .slice(0, 1);
+        .sort(compareScheduleAsc);
+    const nextTime = future[0]?._sortTime || 0;
+    const upcoming = nextTime ? future.filter((schedule) => (schedule._sortTime || 0) === nextTime) : [];
     const upcomingKeys = new Set(upcoming.map(scheduleKey));
     const history = ordered.filter((schedule) => !upcomingKeys.has(scheduleKey(schedule)));
 
@@ -862,10 +869,16 @@ function readExistingSchedules(source) {
     };
 }
 
-function mergeSchedules(existingHistory, incomingHistory, incomingUpcoming) {
+function mergeSchedules(existingHistory, incomingHistory, incomingUpcoming, existingUpcoming = []) {
     const upcomingKeys = new Set(incomingUpcoming.map(scheduleKey));
     const byKey = new Map();
 
+    for (const schedule of existingUpcoming) {
+        const key = scheduleKey(schedule);
+        if (!upcomingKeys.has(key) && !byKey.has(key)) {
+            byKey.set(key, schedule);
+        }
+    }
     for (const schedule of existingHistory) {
         const key = scheduleKey(schedule);
         if (!upcomingKeys.has(key) && !byKey.has(key)) {


### PR DESCRIPTION
- Add June 15, 2026 upcoming schedules
- Move EdgeGen into historical schedules
- Preserve manually maintained facilitator fields during sync
- Support multiple upcoming talks at the same nearest future time
- Update Feishu sync documentation